### PR TITLE
fix Uncaught Error: Vitest failed to access its internal state and fix Module 'util' has been externalized for browser compatibility

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,8 @@
-import SignUpPage from "./page/SignUpPage"
+import SignUpPage from "./page/SignUpPage";
 import { axiosApiService } from "./services/apiService";
 
 function App() {
-  return (
-    <SignUpPage apiService={axiosApiService}/>
-  )
+  return <SignUpPage apiService={axiosApiService} />;
 }
 
-export default App
+export default App;

--- a/src/page/SignUpPage.spec.tsx
+++ b/src/page/SignUpPage.spec.tsx
@@ -5,11 +5,8 @@ import { userEvent } from "@testing-library/user-event";
 import axios from "axios";
 import { vi, beforeEach } from "vitest";
 import { fillAndSubmitSignUpForm } from "../tests/testUtils";
-import {
-  defaultService,
-  axiosApiService,
-  fetchApiService,
-} from "../services/apiService";
+import { axiosApiService, fetchApiService } from "../services/apiService";
+import { defaultService } from "../services/defaultService";
 
 vi.mock("axios");
 const mockedAxios = vi.mocked(axios, { deep: true });

--- a/src/page/SignUpPage.tsx
+++ b/src/page/SignUpPage.tsx
@@ -76,7 +76,6 @@ class SignUpPage extends Component<SignUpPageProps, SignUpState> {
     event.preventDefault();
     const { username, email, password, passwordRepeat } = this.state;
     const body = { username, email, password, passwordRepeat };
-    //this.setState({ isSubmitting: true });
     this.setState({
       isSubmitting: true,
       successMessage: null,

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -1,13 +1,8 @@
 import axios from "axios";
-import { vi } from "vitest";
 
 export interface ApiService {
   post: (url: string, body: Record<string, any>) => Promise<any>;
 }
-
-export const defaultService = {
-  post: vi.fn().mockResolvedValue({}), // Default no-op mock for tests
-};
 
 // Axios implementation
 export const axiosApiService: ApiService = {

--- a/src/services/defaultService.ts
+++ b/src/services/defaultService.ts
@@ -1,0 +1,6 @@
+import { vi } from "vitest";
+import { ApiService } from "../services/apiService";
+
+export const defaultService: ApiService = {
+  post: vi.fn().mockResolvedValue({}), // Default no operation mock for tests
+};


### PR DESCRIPTION
* update "apiService" and "defaultService" configuration to fix the bug.  https://github.com/Nikhilcs36/tdd_react_typescript_vite_vitest_project/commit/7ee0c6d0b91cf7839bc5548c9b1d147d4ab1937d