### PR TITLE
implement i18n Accept-Language in API headers

### DIFF
--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import i18n from "../locale/i18n";
 
 export interface ApiService {
   post: (url: string, body: Record<string, any>) => Promise<any>;
@@ -7,7 +8,11 @@ export interface ApiService {
 // Axios implementation
 export const axiosApiService: ApiService = {
   post: async (url, body) => {
-    const response = await axios.post(url, body);
+    const response = await axios.post(url, body, {
+      headers: {
+        "Accept-Language": i18n.language, // Attach the current language header
+      },
+    });
     return response.data;
   },
 };
@@ -17,7 +22,10 @@ export const fetchApiService: ApiService = {
   post: async (url, body) => {
     const response = await fetch(url, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        "Accept-Language": i18n.language, // Attach the current language header
+      },
       body: JSON.stringify(body),
     });
     if (!response.ok) {

--- a/src/tests/mocks/handlers.ts
+++ b/src/tests/mocks/handlers.ts
@@ -3,6 +3,9 @@ import { SignUpRequestBody, validateSignUp } from "../../utils/validationRules";
 
 export const handlers = [
   http.post("/api/1.0/users", async ({ request }) => {
+    // Capture the Accept-Language header from the request.
+    const acceptLanguage = request.headers.get("Accept-Language");
+
     // Parse and type the request body
     const body = (await request.json()) as SignUpRequestBody;
 
@@ -15,12 +18,17 @@ export const handlers = [
         {
           message: "Validation Failure",
           validationErrors,
+          // Optional, Accept-Language header for testing:
+          languageReceived: acceptLanguage,
         },
         { status: 400 }
       );
     }
 
     // If no validation errors, simulate a successful response
-    return HttpResponse.json({ message: "User created" }, { status: 200 });
+    return HttpResponse.json(
+      { message: "User created", languageReceived: acceptLanguage },
+      { status: 200 }
+    );
   }),
 ];


### PR DESCRIPTION
* implement i18n Accept-Language in API headers (update apiService.ts) and add test 'sends Accept-Language header as '%s' using axiosApiService' and 'sends Accept-Language header as '%s' using fetch ApiService' in SignUpPage.spec.tsx and also update msw mock/handlers.ts with Accept-Language header for testing. https://github.com/Nikhilcs36/tdd_react_typescript_vite_vitest_project/commit/5f2bd0bab537acfc8635622b9afbaf6e6d7f3dab