### PR TITLE
update languageSwitcher.test.tsx to include an I18nextProvider with i18n instance

### DIFF
--- a/src/locale/languageSwitcher.test.tsx
+++ b/src/locale/languageSwitcher.test.tsx
@@ -1,14 +1,19 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import LanguageSwitcher from "./languageSwitcher";
 import { render, screen } from "@testing-library/react";
+import { I18nextProvider } from "react-i18next";
+import i18n from "./i18n";
 
 describe("LanguageSwitcher Style Test", () => {
   let container: HTMLElement;
 
   beforeEach(() => {
-    const { container: cont } = render(<LanguageSwitcher />);
-    // The LanguageSwitcher container is the first child.
-    container = cont.firstChild as HTMLElement;
+    render(
+      <I18nextProvider i18n={i18n}>
+        <LanguageSwitcher />
+      </I18nextProvider>
+    );
+    container = screen.getByTestId("language-switcher");
   });
 
   // Verify that the container is rendered.

--- a/src/locale/languageSwitcher.tsx
+++ b/src/locale/languageSwitcher.tsx
@@ -5,7 +5,7 @@ const LanguageSwitcher = () => {
   const { i18n } = useTranslation();
 
   return (
-    <div css={tw`fixed z-50 flex gap-2 bottom-4 right-4`}>
+    <div data-testid="language-switcher" css={tw`fixed z-50 flex gap-2 bottom-4 right-4`}>
       <button
         onClick={() => i18n.changeLanguage("en")}
         css={tw`px-3 py-1 text-sm text-blue-800 bg-blue-100 rounded hover:bg-blue-200`}


### PR DESCRIPTION
* update languageSwitcher.test.tsx to include an I18nextProvider with i18n instance and change container.firstChild to screen.getByTestId and add data-testid ='language-switcher' in languageSwitcher.tsx  https://github.com/Nikhilcs36/tdd_react_typescript_vite_vitest_project/commit/2da0dcc45d3b87db9642239f4f999c301c313dc2