### PR TITLE
 account_activation_token_not_trigger

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,10 +68,7 @@ function App() {
             />
             <Route path="/login" element={<LoginPage />} />
             <Route path="/user/:id" element={<UserPage />} />
-            <Route
-              path="/activate/:token"
-              element={<AccountActivationPage token={""} />}
-            />
+            <Route path="/activate/:token" element={<AccountActivationPage />} />
           </Routes>
         </Content>
       </Router>

--- a/src/page/accountActivationPage.test.tsx
+++ b/src/page/accountActivationPage.test.tsx
@@ -4,6 +4,7 @@ import AccountActivationPage from "./accountActivationPage";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import axios from "axios";
 import { act } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 
 // Mock axios API call
 vi.mock("axios");
@@ -13,9 +14,33 @@ beforeEach(() => {
   vi.resetAllMocks();
 });
 
+/**
+ * Utility function to render the AccountActivationPage component
+ * within a test-friendly router environment.
+ *
+ * @param {string} initialPath - The initial URL path to simulate in the test.
+ * @returns {RenderResult} - The result of the render function from @testing-library/react.
+ *
+ * Why is this needed?
+ * - We use `MemoryRouter` instead of `BrowserRouter` to control the initial route.
+ * - `initialEntries` allows us to simulate navigating to a specific path.
+ * - `Routes` and `Route` ensure that the correct page is rendered based on the URL.
+ * - This helps us test route-based behavior (e.g., extracting the token from the URL).
+ */
+
+const setup = (initialPath: string) => {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route path="/activate/:token" element={<AccountActivationPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+};
+
 describe("Account Activation Page", () => {
   it("displays activation success message when token is valid", async () => {
-    render(<AccountActivationPage token="123" />);
+    setup("/activate/123");
 
     const message = await screen.findByText("Account is Activated");
     expect(message).toBeInTheDocument();
@@ -27,7 +52,7 @@ describe("Account Activation Page", () => {
       data: { message: "Account Activated" },
     });
 
-    render(<AccountActivationPage token="12315" />);
+    setup("/activate/12315");
 
     // Wait for success message
     const message = await screen.findByTestId("success-message");
@@ -42,7 +67,7 @@ describe("Account Activation Page", () => {
       response: { status: 400, data: { message: "Activation Failed" } },
     });
 
-    render(<AccountActivationPage token="invalid" />);
+    setup("/activate/invalid");
 
     const message = await screen.findByTestId("fail-message");
     expect(message).toBeInTheDocument();
@@ -52,13 +77,13 @@ describe("Account Activation Page", () => {
     );
   });
 
-  it("sends activation request after the token changes (first fail, then success)", async () => {
+  it("sends activation request after the token changes (first fail, then success, then fail again)", async () => {
     // Mock API response for the initial (failed) token
     mockedAxios.post.mockRejectedValueOnce({
       response: { status: 400, data: { message: "Activation Failed" } },
     });
 
-    const { rerender } = render(<AccountActivationPage token="invalid" />);
+    setup("/activate/invalid");
 
     // Ensure API call was made for the first token
     await waitFor(() => {
@@ -68,17 +93,17 @@ describe("Account Activation Page", () => {
     });
 
     // Check that the failure message appears
-    const failMessage = await screen.findByTestId("fail-message");
-    expect(failMessage).toBeInTheDocument();
+    const failMessages = await screen.findAllByTestId("fail-message");
+    expect(failMessages.length).toBeGreaterThan(0);
 
     // Mock API response for the new (successful) token
     mockedAxios.post.mockResolvedValueOnce({
       data: { message: "Account Activated" },
     });
 
-    // Simulate token change
+    // Simulate route change by re-rendering with a different entry
     await act(async () => {
-      rerender(<AccountActivationPage token="valid-token" />);
+      setup("/activate/valid-token");
     });
 
     // Ensure API call was made for the new token
@@ -91,5 +116,25 @@ describe("Account Activation Page", () => {
     // Check that the success message appears
     const successMessage = await screen.findByTestId("success-message");
     expect(successMessage).toBeInTheDocument();
+
+    // Mock API response for the new (failed) token
+    mockedAxios.post.mockRejectedValueOnce({
+      response: { status: 400, data: { message: "Activation Failed" } },
+    });
+
+    // Simulate another route change with the same success token
+    await act(async () => {
+      setup("/activate/valid-token");
+    });
+
+    // Ensure API call was made again for the token
+    await waitFor(() => {
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        "/api/1.0/users/token/valid-token"
+      );
+    });
+    
+    const failMessagesAgain = await screen.findAllByTestId("fail-message");
+    expect(failMessagesAgain.length).toBeGreaterThan(0);
   });
 });

--- a/src/page/accountActivationPage.tsx
+++ b/src/page/accountActivationPage.tsx
@@ -1,15 +1,12 @@
 import { useEffect, useState } from "react";
-//import { useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import tw from "twin.macro";
 import axios from "axios";
 const SuccessMessage = tw.div`mt-3 p-3 text-green-700 bg-green-100 rounded text-center`;
 const ErrorMessage = tw.div`mt-3 p-3 text-red-700 bg-red-100 rounded text-center`;
 
-type Props = {
-  token: string; // Explicitly define token as a required prop
-};
-
-const AccountActivationPage = ({ token }: Props) => {
+const AccountActivationPage = () => {
+  const { token } = useParams<{ token: string }>();
   const [result, setResult] = useState<"success" | "fail" | "">("");
 
   useEffect(() => {


### PR DESCRIPTION
* update test 'sends activation request after the token changes (first fail, then success, then fail again)' in accountActivationPage.test.tsx and Instead of manually passing the token as a prop, extract it inside AccountActivationPage using React Router’s useParams hook in accountActivationPage.tsx and update route url in app.tsx and update corresponding test render setup in accountActivationPage.test.tsx  https://github.com/Nikhilcs36/tdd_react_typescript_vite_vitest_project/commit/09c3f49c47713fd76540c0d189a1f85d45a0cdc2