### PR TITLE
account activation loading

### DIFF
--- a/src/page/accountActivationPage.test.tsx
+++ b/src/page/accountActivationPage.test.tsx
@@ -133,26 +133,62 @@ describe("Account Activation Page", () => {
         "/api/1.0/users/token/valid-token"
       );
     });
-    
+
     const failMessagesAgain = await screen.findAllByTestId("fail-message");
     expect(failMessagesAgain.length).toBeGreaterThan(0);
   });
-  
+
   it("displays spinner during activation API call", async () => {
     // Mock API response before rendering
     mockedAxios.post.mockResolvedValueOnce({
       data: { message: "Account Activated" },
     });
-  
+
     setup("/activate/5678");
-  
+
     // Check if the spinner appears initially
     expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
-  
-    // Wait for the success message
+
+    // Wait for the success messageḍ
     await screen.findByTestId("success-message");
-  
+
     // Ensure spinner disappears
     expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument();
-  });  
+  });
+
+  it("displays spinner during second activation API call to the changed token", async () => {
+    // Mock API response for the first activation attempt
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { message: "Account Activated" },
+    });
+  
+    setup("/activate/1234");
+  
+    // Wait for the spinner to appear
+    await screen.findByTestId("loading-spinner");
+  
+    // Wait for the success message to confirm activation
+    await screen.findByTestId("success-message");
+  
+    // Ensure spinner disappears after the first activation
+    expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument();
+  
+    // Mock API response for the second activation attempt
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { message: "Activation failure" },
+    });
+  
+    // Simulate route change by re-rendering with a different token
+    setup("/activate/5678");
+  
+    await screen.findByTestId("loading-spinner");
+    
+    await waitFor(() => {
+      screen.findByTestId("fail-message");
+    });
+    
+    // Ensure the spinner disappears after the second activation attempt
+    expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument();
+  });
+  
 });

--- a/src/page/accountActivationPage.test.tsx
+++ b/src/page/accountActivationPage.test.tsx
@@ -137,4 +137,22 @@ describe("Account Activation Page", () => {
     const failMessagesAgain = await screen.findAllByTestId("fail-message");
     expect(failMessagesAgain.length).toBeGreaterThan(0);
   });
+  
+  it("displays spinner during activation API call", async () => {
+    // Mock API response before rendering
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { message: "Account Activated" },
+    });
+  
+    setup("/activate/5678");
+  
+    // Check if the spinner appears initially
+    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+  
+    // Wait for the success message
+    await screen.findByTestId("success-message");
+  
+    // Ensure spinner disappears
+    expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument();
+  });  
 });

--- a/src/page/accountActivationPage.test.tsx
+++ b/src/page/accountActivationPage.test.tsx
@@ -3,7 +3,6 @@ import { render, screen, waitFor } from "@testing-library/react";
 import AccountActivationPage from "./accountActivationPage";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import axios from "axios";
-import { act } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 
 // Mock axios API call
@@ -102,9 +101,7 @@ describe("Account Activation Page", () => {
     });
 
     // Simulate route change by re-rendering with a different entry
-    await act(async () => {
-      setup("/activate/valid-token");
-    });
+    setup("/activate/valid-token");
 
     // Ensure API call was made for the new token
     await waitFor(() => {
@@ -123,9 +120,7 @@ describe("Account Activation Page", () => {
     });
 
     // Simulate another route change with the same success token
-    await act(async () => {
-      setup("/activate/valid-token");
-    });
+    setup("/activate/valid-token");
 
     // Ensure API call was made again for the token
     await waitFor(() => {
@@ -186,7 +181,7 @@ describe("Account Activation Page", () => {
     await waitFor(() => {
       screen.findByTestId("fail-message");
     });
-    
+
     // Ensure the spinner disappears after the second activation attempt
     expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument();
   });

--- a/src/page/accountActivationPage.tsx
+++ b/src/page/accountActivationPage.tsx
@@ -2,24 +2,31 @@ import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import tw from "twin.macro";
 import axios from "axios";
+
 const SuccessMessage = tw.div`mt-3 p-3 text-green-700 bg-green-100 rounded text-center`;
 const ErrorMessage = tw.div`mt-3 p-3 text-red-700 bg-red-100 rounded text-center`;
+const Spinner = tw.div`mt-3 w-6 h-6 border-4 border-blue-500 border-t-transparent rounded-full animate-spin mx-auto`;
 
 const AccountActivationPage = () => {
   const { token } = useParams<{ token: string }>();
   const [result, setResult] = useState<"success" | "fail" | "">("");
+  const [loading, setLoading] = useState<boolean>(false);
 
   useEffect(() => {
     if (!token) {
-      setResult("fail"); // Directly fail if token is missing
+      setResult("fail");
       return;
     }
+
     const activateAccount = async () => {
+      setLoading(true);
       try {
         await axios.post(`/api/1.0/users/token/${token}`);
         setResult("success");
       } catch (error) {
         setResult("fail");
+      } finally {
+        setLoading(false);
       }
     };
 
@@ -28,6 +35,7 @@ const AccountActivationPage = () => {
 
   return (
     <div data-testid="activation-page">
+      {loading && <Spinner data-testid="loading-spinner" />}
       {result === "success" && (
         <SuccessMessage data-testid="success-message">
           Account is Activated


### PR DESCRIPTION
* add test 'displays spinner during activation API call' in accountActivationPage.test.tsx and implement loading-spinner logic in accountActivationPage.tsx  https://github.com/Nikhilcs36/tdd_react_typescript_vite_vitest_project/commit/d81879d697b0782995e408a817258c2736066751
* add test 'displays spinner during second activation API call to the changed token' in accountActivationPage.test.tsx https://github.com/Nikhilcs36/tdd_react_typescript_vite_vitest_project/pull/85/commits/a636babbd8c33837a322fd6050977734d1cc3b7e
* update test with remove act() because the test flow is properly waiting for API calls and UI updates using waitFor() and findByTestId() https://github.com/Nikhilcs36/tdd_react_typescript_vite_vitest_project/pull/85/commits/a7e1712c2b9f36738fa288765f9f90edd9ecd170