### PR TITLE
Update dark mode with sun and moon switcher

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react-redux": "^9.2.0",
         "react-router-dom": "^7.2.0",
         "redux": "^5.0.1",
+        "secure-ls": "^2.0.0",
         "styled-components": "^6.1.14"
       },
       "devDependencies": {
@@ -2914,6 +2915,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
+    },
     "node_modules/css-color-keywords": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
@@ -4265,7 +4272,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "lz-string": "bin/bin.js"
@@ -5347,6 +5353,19 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/secure-ls": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/secure-ls/-/secure-ls-2.0.0.tgz",
+      "integrity": "sha512-Wgtnw0QSm0v7gVKv11nOoeyGS65EThGXnBB7jfd4IhZd2eq3B4AMPcXAL5qJ1h55+Qolun7TONTwX7H5m6e2pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "crypto-js": "^4.2.0",
+        "lz-string": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-redux": "^9.2.0",
     "react-router-dom": "^7.2.0",
     "redux": "^5.0.1",
+    "secure-ls": "^2.0.0",
     "styled-components": "^6.1.14"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import { Provider, useSelector } from "react-redux";
 import store, { RootState } from "./store";
 import { useLogout } from "./components/logout/useLogout";
 import LogoutMessage from "./components/logout/LogoutMessage";
+import { ThemeSwitcher } from "./components/ThemeSwitcher";
 
 // Navbar styled components
 const NavBar = tw.nav`
@@ -43,13 +44,6 @@ const NavBar = tw.nav`
 const NavLeft = tw.div`flex items-center gap-4`;
 const NavRight = tw.div`flex items-center gap-6`;
 const NavLink = tw(Link)`
-  font-semibold
-  cursor-pointer
-  hover:underline
-  transition-all
-  duration-200
-`;
-const ThemeSwitcher = tw.div`
   font-semibold
   cursor-pointer
   hover:underline
@@ -83,7 +77,7 @@ export const AppContent = ({
   const { logout: logoutUser } = useLogout(logoutApiService);
   const [theme, setTheme] = useState(() => {
     const savedTheme = localStorage.getItem("theme");
-    return savedTheme || "light";
+    return (savedTheme || "light") as "light" | "dark";
   });
 
   useEffect(() => {
@@ -106,12 +100,7 @@ export const AppContent = ({
           <NavLink to="/" title="Home">
             {t("home")}
           </NavLink>
-          <ThemeSwitcher
-            onClick={handleThemeSwitch}
-            data-testid="theme-switcher"
-          >
-            {theme === "light" ? "Dark" : "Light"} Mode
-          </ThemeSwitcher>
+          <ThemeSwitcher onClick={handleThemeSwitch} theme={theme} />
         </NavLeft>
         <NavRight>
           {isAuthenticated ? (

--- a/src/components/ThemeSwitcher.test.tsx
+++ b/src/components/ThemeSwitcher.test.tsx
@@ -1,0 +1,26 @@
+import { render, fireEvent, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { ThemeSwitcher } from "./ThemeSwitcher";
+
+describe("ThemeSwitcher", () => {
+  it("renders sun icon with light theme", () => {
+    render(<ThemeSwitcher onClick={() => {}} theme="light" />);
+    const themeSwitcher = screen.getByTestId("theme-switcher");
+    const sunIcon = themeSwitcher.querySelector("svg");
+    expect(sunIcon).toBeInTheDocument();
+  });
+
+  it("renders moon icon with dark theme", () => {
+    render(<ThemeSwitcher onClick={() => {}} theme="dark" />);
+    const themeSwitcher = screen.getByTestId("theme-switcher");
+    const moonIcon = themeSwitcher.querySelector("svg");
+    expect(moonIcon).toBeInTheDocument();
+  });
+
+  it("calls onClick when clicked", () => {
+    const handleClick = vi.fn();
+    render(<ThemeSwitcher onClick={handleClick} theme="light" />);
+    fireEvent.click(screen.getByTestId("theme-switcher"));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import tw from "twin.macro";
+
+// Define styled components
+const SwitcherContainer = tw.div`
+  w-12
+  h-6
+  rounded-full
+  p-1
+  flex
+  items-center
+  cursor-pointer
+  transition-colors
+  duration-300
+  relative
+`;
+
+const IconContainer = tw.div`
+  w-5
+  h-5
+  rounded-full
+  bg-white
+  dark:bg-gray-800
+  shadow-md
+  transform
+  transition-transform
+  duration-300
+  absolute
+  flex
+  items-center
+  justify-center
+`;
+
+const SunIcon = tw.svg`
+  w-4
+  h-4
+  text-yellow-500
+  transition-opacity
+  duration-300
+`;
+
+const MoonIcon = tw.svg`
+  w-4
+  h-4
+  text-gray-400
+  transition-opacity
+  duration-300
+`;
+
+interface ThemeSwitcherProps {
+  onClick: () => void;
+  theme: "light" | "dark";
+}
+
+export const ThemeSwitcher: React.FC<ThemeSwitcherProps> = ({
+  onClick,
+  theme,
+}) => {
+  return (
+    <SwitcherContainer
+      onClick={onClick}
+      data-testid="theme-switcher"
+      className={theme === "light" ? "bg-blue-400" : "bg-gray-700"}
+    >
+      <IconContainer
+        style={{
+          transform:
+            theme === "light" ? "translateX(0)" : "translateX(calc(100% + 4px))",
+        }}
+      >
+        {theme === "light" ? (
+          <SunIcon
+            xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 3v1m0 16v1m8.66-12.66l-.7.7M4.04 19.96l-.7.7M21 12h-1M4 12H3m16.66 7.34l-.7-.7M4.04 4.04l-.7-.7"
+              />
+            </SunIcon>
+          ) : (
+            <MoonIcon
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"
+              />
+            </MoonIcon>
+          )}
+      </IconContainer>
+    </SwitcherContainer>
+  );
+};

--- a/src/main.test.tsx
+++ b/src/main.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { initializeTheme } from './main';
+
+describe('Theme Initialization', () => {
+  afterEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('dark');
+  });
+
+  it('should add "dark" class to html element if theme is "dark" in localStorage', () => {
+    localStorage.setItem('theme', 'dark');
+    initializeTheme();
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('should not add "dark" class to html element if theme is not "dark" in localStorage', () => {
+    localStorage.setItem('theme', 'light');
+    initializeTheme();
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('should not add "dark" class to html element if theme is not in localStorage', () => {
+    initializeTheme();
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,9 +4,27 @@ import './index.css'
 import App from './App.tsx'
 import GlobalStyles from './styles/GlobalStyles.tsx'
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <GlobalStyles />
-    <App />
-  </StrictMode>,
-)
+// Initialize theme before React hydration
+export const initializeTheme = () => {
+  const savedTheme = localStorage.getItem('theme');
+  if (savedTheme === 'dark') {
+    document.documentElement.classList.add('dark');
+  } else {
+    document.documentElement.classList.remove('dark');
+  }
+};
+
+initializeTheme();
+
+export const renderApp = () => {
+  createRoot(document.getElementById('root')!).render(
+    <StrictMode>
+      <GlobalStyles />
+      <App />
+    </StrictMode>,
+  );
+};
+
+if (import.meta.env.MODE !== 'test') {
+  renderApp();
+}


### PR DESCRIPTION
* [successfully replaced dark mode text-based theme switcher with an animated sun/moon icon](https://github.com/Nikhilcs36/tdd_react_typescript_vite_vitest_project/commit/ad7687ebfd0a999e5b4e536d9977916b3d66d7a0) 

 *[added a test for the theme initialization logic in src/main.tsx](https://github.com/Nikhilcs36/tdd_react_typescript_vite_vitest_project/commit/ee21d811cbd9bd55cdccae22beae229116eba2e3)
I implemented this because the dark mode theme was flickering when the page was refreshed, so I needed to add a test because the default light mode was changing due to the refresh.