### PR TITLE
"clear image" checkbox to a button in the ProfilePage component

### DIFF
--- a/src/page/ProfilePage.test.tsx
+++ b/src/page/ProfilePage.test.tsx
@@ -414,7 +414,7 @@ describe("ProfilePage", () => {
       });
     });
 
-    it("sends a null image field when the clear image checkbox is checked", async () => {
+    it("sends a null image field when the clear image button is clicked", async () => {
       const { mockPut } = await setup({ withAuth: true });
 
       // Wait for user data to load
@@ -425,9 +425,9 @@ describe("ProfilePage", () => {
       // Enter edit mode
       fireEvent.click(screen.getByTestId("edit-profile-button"));
 
-      // Find and click the clear image checkbox
-      const clearImageCheckbox = screen.getByTestId("clear-image-checkbox");
-      fireEvent.click(clearImageCheckbox);
+      // Find and click the clear image button
+      const clearImageButton = screen.getByTestId("clear-image-button");
+      fireEvent.click(clearImageButton);
 
       // Submit the form
       fireEvent.click(screen.getByTestId("save-profile-button"));
@@ -443,7 +443,7 @@ describe("ProfilePage", () => {
       });
     });
 
-    it("unchecks the clear image checkbox after successful submission", async () => {
+    it("resets the clear image state after successful submission", async () => {
       await setup({ withAuth: true });
 
       // Wait for user data to load
@@ -454,14 +454,9 @@ describe("ProfilePage", () => {
       // Enter edit mode
       fireEvent.click(screen.getByTestId("edit-profile-button"));
 
-      // Find and click the clear image checkbox
-      const clearImageCheckbox = screen.getByTestId(
-        "clear-image-checkbox"
-      ) as HTMLInputElement;
-      fireEvent.click(clearImageCheckbox);
-
-      // Verify checkbox is checked
-      expect(clearImageCheckbox.checked).toBe(true);
+      // Find and click the clear image button
+      const clearImageButton = screen.getByTestId("clear-image-button");
+      fireEvent.click(clearImageButton);
 
       // Submit the form
       fireEvent.click(screen.getByTestId("save-profile-button"));
@@ -473,14 +468,44 @@ describe("ProfilePage", () => {
         ).toBeInTheDocument();
       });
 
-      // Re-enter edit mode to check the state of the checkbox
+      // Re-enter edit mode to check the state of the button
       fireEvent.click(screen.getByTestId("edit-profile-button"));
 
-      // Verify that the checkbox is now unchecked
-      const updatedClearImageCheckbox = screen.getByTestId(
-        "clear-image-checkbox"
-      ) as HTMLInputElement;
-      expect(updatedClearImageCheckbox.checked).toBe(false);
+      // Verify that the clear image button is enabled (meaning no image is set to be cleared)
+      const updatedClearImageButton = screen.getByTestId("clear-image-button");
+      expect(updatedClearImageButton).toBeEnabled();
+    });
+
+    it("disables clear image button when there is no existing profile image", async () => {
+      await setup({ userData: { ...baseUser, image: null } });
+
+      // Wait for user data to load
+      await waitFor(() =>
+        expect(screen.getByTestId("username")).toBeInTheDocument()
+      );
+
+      // Enter edit mode
+      fireEvent.click(screen.getByTestId("edit-profile-button"));
+
+      // Verify that the clear image button is disabled
+      const clearImageButton = screen.getByTestId("clear-image-button");
+      expect(clearImageButton).toBeDisabled();
+    });
+
+    it("enables clear image button when there is an existing profile image", async () => {
+      await setup({ userData: { ...baseUser, image: "https://example.com/image.jpg" } });
+
+      // Wait for user data to load
+      await waitFor(() =>
+        expect(screen.getByTestId("username")).toBeInTheDocument()
+      );
+
+      // Enter edit mode
+      fireEvent.click(screen.getByTestId("edit-profile-button"));
+
+      // Verify that the clear image button is enabled
+      const clearImageButton = screen.getByTestId("clear-image-button");
+      expect(clearImageButton).toBeEnabled();
     });
 
     it("clears previous image upload error when a new image is selected", async () => {

--- a/src/page/ProfilePage.tsx
+++ b/src/page/ProfilePage.tsx
@@ -224,9 +224,15 @@ class ProfilePage extends Component<ProfilePageProps, ProfilePageState> {
     return Object.keys(validationErrors).length === 0;
   };
 
-  // Handle checkbox change for clearing the image
-  handleClearImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    this.setState({ clearImage: e.target.checked });
+  // Handle button click for clearing the image
+  handleClearImageClick = () => {
+    this.setState({ 
+      clearImage: true,
+      editForm: {
+        ...this.state.editForm,
+        image: ""
+      }
+    });
   };
 
   // Update handleSubmit to properly call the API service with file upload support
@@ -471,18 +477,15 @@ class ProfilePage extends Component<ProfilePageProps, ProfilePageState> {
         </FormGroup>
 
         <FormGroup>
-          <div className="flex items-center">
-            <input
-              type="checkbox"
-              id="clearImage"
-              name="clearImage"
-              checked={this.state.clearImage}
-              onChange={this.handleClearImageChange}
-              data-testid="clear-image-checkbox"
-              className="mr-2"
-            />
-            <Label htmlFor="clearImage">{t("profile.removeProfileImage")}</Label>
-          </div>
+          <button
+            type="button"
+            onClick={this.handleClearImageClick}
+            disabled={!this.state.editForm.image}
+            data-testid="clear-image-button"
+            className="px-4 py-2 font-bold text-white bg-red-500 rounded hover:bg-red-700 disabled:bg-red-300 disabled:cursor-not-allowed"
+          >
+            {t("profile.removeProfileImage")}
+          </button>
         </FormGroup>
 
         <FormGroup>


### PR DESCRIPTION
* [clear-image-checkbox to clear-image-button and set disables clear image button when there is no existing profile image and enables clear image button when there is an existing profile image](https://github.com/Nikhilcs36/tdd_react_typescript_vite_vitest_project/commit/f4ca630f238e8928f260c723ac9e572bde58fc3b)