### PR TITLE
feat: implement email verification API services and i18n translations

### DIFF
--- a/src/locale/emailVerification.i18n.test.ts
+++ b/src/locale/emailVerification.i18n.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import i18n from "./i18n";
+
+describe("Email Verification i18n", () => {
+  beforeEach(async () => {
+    // Reset to English before each test
+    await i18n.changeLanguage("en");
+  });
+
+  describe("login.errors.email_not_verified", () => {
+    it.each([
+      {
+        lang: "en",
+        expectedMessage: "Please verify your email before logging in.",
+      },
+      {
+        lang: "ml",
+        expectedMessage: "ലോഗിൻ ചെയ്യുന്നതിന് മുമ്പ് ദയവായി നിങ്ങളുടെ ഇമെയിൽ പരിശോധിക്കുക.",
+      },
+      {
+        lang: "ar",
+        expectedMessage: "يرجى التحقق من بريدك الإلكتروني قبل تسجيل الدخول.",
+      },
+    ])("displays email_not_verified error correctly in $lang", async ({ lang, expectedMessage }) => {
+      await i18n.changeLanguage(lang);
+      const translatedMessage = i18n.t("login.errors.email_not_verified");
+      expect(translatedMessage).toBe(expectedMessage);
+    });
+  });
+
+  describe("Email verification page translations", () => {
+    it.each([
+      {
+        lang: "en",
+        expectedTitle: "Email Verification",
+        expectedVerifying: "Verifying your email...",
+        expectedSuccessTitle: "Email Verified!",
+        expectedSuccessMessage: "Your email has been successfully verified.",
+        expectedLoginButton: "Go to Login",
+        expectedErrorExpired: "Verification link has expired. Please request a new one.",
+        expectedErrorInvalid: "Invalid verification token.",
+        expectedResendButton: "Resend Verification Email",
+      },
+      {
+        lang: "ml",
+        expectedTitle: "ഇമെയിൽ വെരിഫിക്കേഷൻ",
+        expectedVerifying: "നിങ്ങളുടെ ഇമെയിൽ പരിശോധിക്കുന്നു...",
+        expectedSuccessTitle: "ഇമെയിൽ വെരിഫൈഡ്!",
+        expectedSuccessMessage: "നിങ്ങളുടെ ഇമെയിൽ വിജയകരമായി വെരിഫൈ ചെയ്യപ്പെട്ടു.",
+        expectedLoginButton: "ലോഗിനിലേക്ക് പോകുക",
+        expectedErrorExpired: "വെരിഫിക്കേഷൻ ലിങ്കിന്റെ കാലാവധി കഴിഞ്ഞു. ദയവായി പുതിയത് അഭ്യർത്ഥിക്കുക.",
+        expectedErrorInvalid: "അസാധുവായ വെരിഫിക്കേഷൻ ടോക്കൺ.",
+        expectedResendButton: "വെരിഫിക്കേഷൻ ഇമെയിൽ വീണ്ടും അയക്കുക",
+      },
+      {
+        lang: "ar",
+        expectedTitle: "التحقق من البريد الإلكتروني",
+        expectedVerifying: "جاري التحقق من بريدك الإلكتروني...",
+        expectedSuccessTitle: "تم التحقق من البريد الإلكتروني!",
+        expectedSuccessMessage: "تم التحقق من بريدك الإلكتروني بنجاح.",
+        expectedLoginButton: "الذهاب إلى تسجيل الدخول",
+        expectedErrorExpired: "انتهت صلاحية رابط التحقق. يرجى طلب رابط جديد.",
+        expectedErrorInvalid: "رمز التحقق غير صالح.",
+        expectedResendButton: "إعادة إرسال بريد التحقق",
+      },
+    ])(
+      "displays email verification translations correctly in $lang",
+      async ({
+        lang,
+        expectedTitle,
+        expectedVerifying,
+        expectedSuccessTitle,
+        expectedSuccessMessage,
+        expectedLoginButton,
+        expectedErrorExpired,
+        expectedErrorInvalid,
+        expectedResendButton,
+      }) => {
+        await i18n.changeLanguage(lang);
+
+        expect(i18n.t("emailVerification.title")).toBe(expectedTitle);
+        expect(i18n.t("emailVerification.verifying")).toBe(expectedVerifying);
+        expect(i18n.t("emailVerification.success.title")).toBe(expectedSuccessTitle);
+        expect(i18n.t("emailVerification.success.message")).toBe(expectedSuccessMessage);
+        expect(i18n.t("emailVerification.success.loginButton")).toBe(expectedLoginButton);
+        expect(i18n.t("emailVerification.errors.expired")).toBe(expectedErrorExpired);
+        expect(i18n.t("emailVerification.errors.invalid")).toBe(expectedErrorInvalid);
+        expect(i18n.t("emailVerification.resend.button")).toBe(expectedResendButton);
+      }
+    );
+  });
+});

--- a/src/locale/i18n.ts
+++ b/src/locale/i18n.ts
@@ -66,6 +66,7 @@ i18n.use(initReactI18next).init({
             password_required: "Password is required.",
             no_active_account:
               "No active account found with the given credentials.",
+            email_not_verified: "Please verify your email before logging in.",
             generic: "An unexpected error occurred.",
           },
         },
@@ -182,6 +183,22 @@ i18n.use(initReactI18next).init({
           user_not_found: "User not found",
           unauthorized_access: "Unauthorized access to dashboard data"
         },
+        emailVerification: {
+          title: "Email Verification",
+          verifying: "Verifying your email...",
+          success: {
+            title: "Email Verified!",
+            message: "Your email has been successfully verified.",
+            loginButton: "Go to Login",
+          },
+          errors: {
+            expired: "Verification link has expired. Please request a new one.",
+            invalid: "Invalid verification token.",
+          },
+          resend: {
+            button: "Resend Verification Email",
+          },
+        },
       },
     },
     ml: {
@@ -242,6 +259,7 @@ i18n.use(initReactI18next).init({
             password_required: "പാസ്‌വേഡ് ആവശ്യമാണ്.",
             no_active_account:
               "നൽകിയിട്ടുള്ള ക്രെഡൻഷ്യലുകൾ ഉപയോഗിച്ച് സജീവമായ അക്കൗണ്ട് കണ്ടെത്താനായില്ല",
+            email_not_verified: "ലോഗിൻ ചെയ്യുന്നതിന് മുമ്പ് ദയവായി നിങ്ങളുടെ ഇമെയിൽ പരിശോധിക്കുക.",
             generic: "ഒരു അപ്രതീക്ഷിത പിശക് സംഭവിച്ചു.",
           },
         },
@@ -353,6 +371,22 @@ i18n.use(initReactI18next).init({
           user_not_found: "ഉപയോക്താവിനെ കണ്ടെത്തിയില്ല",
           unauthorized_access: "ഡാഷ്ബോർഡ് ഡാറ്റയിലേക്ക് അനധികൃത ആക്സസ്"
         },
+        emailVerification: {
+          title: "ഇമെയിൽ വെരിഫിക്കേഷൻ",
+          verifying: "നിങ്ങളുടെ ഇമെയിൽ പരിശോധിക്കുന്നു...",
+          success: {
+            title: "ഇമെയിൽ വെരിഫൈഡ്!",
+            message: "നിങ്ങളുടെ ഇമെയിൽ വിജയകരമായി വെരിഫൈ ചെയ്യപ്പെട്ടു.",
+            loginButton: "ലോഗിനിലേക്ക് പോകുക",
+          },
+          errors: {
+            expired: "വെരിഫിക്കേഷൻ ലിങ്കിന്റെ കാലാവധി കഴിഞ്ഞു. ദയവായി പുതിയത് അഭ്യർത്ഥിക്കുക.",
+            invalid: "അസാധുവായ വെരിഫിക്കേഷൻ ടോക്കൺ.",
+          },
+          resend: {
+            button: "വെരിഫിക്കേഷൻ ഇമെയിൽ വീണ്ടും അയക്കുക",
+          },
+        },
       },
     },
     ar: {
@@ -413,6 +447,7 @@ i18n.use(initReactI18next).init({
             password_required: "يرجى إدخال كلمة المرور.",
             no_active_account:
               "لم يتم العثور على حساب نشط ببيانات الاعتماد المقدمة",
+            email_not_verified: "يرجى التحقق من بريدك الإلكتروني قبل تسجيل الدخول.",
             generic: "حدث خطأ غير متوقع.",
           },
         },
@@ -522,6 +557,22 @@ i18n.use(initReactI18next).init({
           },
           user_not_found: "لم يتم العثور على المستخدم",
           unauthorized_access: "وصول غير مصرح به لبيانات لوحة التحكم"
+        },
+        emailVerification: {
+          title: "التحقق من البريد الإلكتروني",
+          verifying: "جاري التحقق من بريدك الإلكتروني...",
+          success: {
+            title: "تم التحقق من البريد الإلكتروني!",
+            message: "تم التحقق من بريدك الإلكتروني بنجاح.",
+            loginButton: "الذهاب إلى تسجيل الدخول",
+          },
+          errors: {
+            expired: "انتهت صلاحية رابط التحقق. يرجى طلب رابط جديد.",
+            invalid: "رمز التحقق غير صالح.",
+          },
+          resend: {
+            button: "إعادة إرسال بريد التحقق",
+          },
         },
       },
     },

--- a/src/services/__tests__/emailVerification.api.test.ts
+++ b/src/services/__tests__/emailVerification.api.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import axios from "axios";
+import {
+  axiosApiServiceVerifyEmail,
+  fetchApiServiceVerifyEmail,
+  axiosApiServiceResendVerification,
+  fetchApiServiceResendVerification,
+} from "../apiService";
+import { API_ENDPOINTS } from "../apiEndpoints";
+
+// Mock axios
+vi.mock("axios");
+const mockedAxios = vi.mocked(axios, { deep: true });
+
+// Mock i18n
+vi.mock("../../locale/i18n", () => ({
+  default: {
+    language: "en",
+  },
+}));
+
+// Mock store
+vi.mock("../../store", () => ({
+  default: {
+    getState: () => ({
+      auth: {
+        accessToken: null,
+      },
+    }),
+    dispatch: vi.fn(),
+  },
+}));
+
+describe("Email Verification API Services", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("axiosApiServiceVerifyEmail", () => {
+    it("should verify email with valid token successfully", async () => {
+      const mockResponse = {
+        data: {
+          message: "Email verified successfully. You can now log in.",
+        },
+      };
+      mockedAxios.post.mockResolvedValue(mockResponse);
+
+      const token = "valid-verification-token";
+      const result = await axiosApiServiceVerifyEmail.post(
+        API_ENDPOINTS.VERIFY_EMAIL(token)
+      );
+
+      expect(result).toEqual(mockResponse.data);
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        `/api/user/verify-email/${token}/`,
+        {},
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            "Accept-Language": "en",
+          }),
+        })
+      );
+    });
+
+    it("should throw error when token is invalid", async () => {
+      const mockError = {
+        response: {
+          status: 400,
+          data: {
+            error: "Invalid verification token.",
+          },
+        },
+      };
+      mockedAxios.post.mockRejectedValue(mockError);
+
+      const token = "invalid-token";
+
+      await expect(
+        axiosApiServiceVerifyEmail.post(API_ENDPOINTS.VERIFY_EMAIL(token))
+      ).rejects.toEqual(expect.objectContaining(mockError));
+    });
+
+    it("should throw error when token has expired", async () => {
+      const mockError = {
+        response: {
+          status: 400,
+          data: {
+            error: "Verification token has expired. Please request a new one.",
+          },
+        },
+      };
+      mockedAxios.post.mockRejectedValue(mockError);
+
+      const token = "expired-token";
+
+      await expect(
+        axiosApiServiceVerifyEmail.post(API_ENDPOINTS.VERIFY_EMAIL(token))
+      ).rejects.toEqual(expect.objectContaining(mockError));
+    });
+  });
+
+  describe("fetchApiServiceVerifyEmail", () => {
+    it("should verify email with valid token successfully", async () => {
+      const mockResponse = {
+        message: "Email verified successfully. You can now log in.",
+      };
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      });
+
+      const token = "valid-verification-token";
+      const result = await fetchApiServiceVerifyEmail.post(
+        API_ENDPOINTS.VERIFY_EMAIL(token)
+      );
+
+      expect(result).toEqual(mockResponse);
+      expect(global.fetch).toHaveBeenCalledWith(
+        `/api/user/verify-email/${token}/`,
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            "Accept-Language": "en",
+          }),
+        })
+      );
+    });
+
+    it("should throw error when token is invalid", async () => {
+      const mockError = {
+        error: "Invalid verification token.",
+      };
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: () => Promise.resolve(mockError),
+      });
+
+      const token = "invalid-token";
+
+      await expect(
+        fetchApiServiceVerifyEmail.post(API_ENDPOINTS.VERIFY_EMAIL(token))
+      ).rejects.toThrow();
+    });
+
+    it("should throw error when token has expired", async () => {
+      const mockError = {
+        error: "Verification token has expired. Please request a new one.",
+      };
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: () => Promise.resolve(mockError),
+      });
+
+      const token = "expired-token";
+
+      await expect(
+        fetchApiServiceVerifyEmail.post(API_ENDPOINTS.VERIFY_EMAIL(token))
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("axiosApiServiceResendVerification", () => {
+    it("should resend verification email successfully", async () => {
+      const mockResponse = {
+        data: {
+          message: "Verification email sent.",
+        },
+      };
+      mockedAxios.post.mockResolvedValue(mockResponse);
+
+      const email = "test@example.com";
+      const result = await axiosApiServiceResendVerification.post(
+        API_ENDPOINTS.RESEND_VERIFICATION,
+        { email }
+      );
+
+      expect(result).toEqual(mockResponse.data);
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        "/api/user/resend-verification/",
+        { email },
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            "Accept-Language": "en",
+          }),
+        })
+      );
+    });
+
+    it("should handle errors when resending verification email", async () => {
+      const mockError = {
+        response: {
+          status: 400,
+          data: {
+            error: "Failed to resend verification email.",
+          },
+        },
+      };
+      mockedAxios.post.mockRejectedValue(mockError);
+
+      const email = "test@example.com";
+
+      await expect(
+        axiosApiServiceResendVerification.post(
+          API_ENDPOINTS.RESEND_VERIFICATION,
+          { email }
+        )
+      ).rejects.toEqual(expect.objectContaining(mockError));
+    });
+  });
+
+  describe("fetchApiServiceResendVerification", () => {
+    it("should resend verification email successfully", async () => {
+      const mockResponse = {
+        message: "Verification email sent.",
+      };
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      });
+
+      const email = "test@example.com";
+      const result = await fetchApiServiceResendVerification.post(
+        API_ENDPOINTS.RESEND_VERIFICATION,
+        { email }
+      );
+
+      expect(result).toEqual(mockResponse);
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/user/resend-verification/",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            "Content-Type": "application/json",
+            "Accept-Language": "en",
+          }),
+          body: JSON.stringify({ email }),
+        })
+      );
+    });
+
+    it("should handle errors when resending verification email", async () => {
+      const mockError = {
+        error: "Failed to resend verification email.",
+      };
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: () => Promise.resolve(mockError),
+      });
+
+      const email = "test@example.com";
+
+      await expect(
+        fetchApiServiceResendVerification.post(
+          API_ENDPOINTS.RESEND_VERIFICATION,
+          { email }
+        )
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/src/services/apiEndpoints.ts
+++ b/src/services/apiEndpoints.ts
@@ -27,4 +27,8 @@ export const API_ENDPOINTS = {
   USER_STATS_BY_ID: (userId: number) => `/api/user/${userId}/dashboard/stats/`,
   LOGIN_ACTIVITY_BY_ID: (userId: number) => `/api/user/${userId}/dashboard/login-activity/`,
   ADMIN_USER_STATS: "/api/admin/dashboard/users/stats/",
+
+  // Email Verification Endpoints
+  VERIFY_EMAIL: (token: string) => `/api/user/verify-email/${token}/`,
+  RESEND_VERIFICATION: "/api/user/resend-verification/",
 };

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -625,3 +625,77 @@ export const fetchApiServiceDeleteUser: ApiDeleteService = {
     return response.json() as Promise<R>;
   },
 };
+
+// Email verification request body type
+export interface EmailVerificationRequestBody {
+  email: string;
+}
+
+// Axios implementation for email verification
+export const axiosApiServiceVerifyEmail: ApiService = {
+  post: async <T>(url: string) => {
+    const response = await axios.post<T>(
+      url,
+      {},
+      {
+        headers: {
+          "Accept-Language": i18n.language,
+        },
+      }
+    );
+    return response.data;
+  },
+};
+
+// Fetch implementation for email verification (for MSW testing)
+export const fetchApiServiceVerifyEmail: ApiService = {
+  post: async <T>(url: string) => {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Accept-Language": i18n.language,
+      },
+    });
+    if (!response.ok) {
+      const errorData = await response.json();
+      throw handleApiError({
+        response: { status: response.status, data: errorData },
+      });
+    }
+    return response.json() as T;
+  },
+};
+
+// Axios implementation for resend verification email
+export const axiosApiServiceResendVerification: ApiService<EmailVerificationRequestBody> = {
+  post: async <T>(url: string, body?: EmailVerificationRequestBody) => {
+    const response = await axios.post<T>(url, body, {
+      headers: {
+        "Accept-Language": i18n.language,
+      },
+    });
+    return response.data;
+  },
+};
+
+// Fetch implementation for resend verification email (for MSW testing)
+export const fetchApiServiceResendVerification: ApiService<EmailVerificationRequestBody> = {
+  post: async <T>(url: string, body?: EmailVerificationRequestBody) => {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Accept-Language": i18n.language,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      throw handleApiError({
+        response: { status: response.status, data: errorData },
+      });
+    }
+    return response.json() as T;
+  },
+};

--- a/src/tests/mocks/handlers.ts
+++ b/src/tests/mocks/handlers.ts
@@ -115,7 +115,7 @@ export const handlers = [
     );
   }),
 
-// Mock API for userlist (msw) - Authorization aware ----(3)
+  // Mock API for userlist (msw) - Authorization aware ----(3)
   http.get(API_ENDPOINTS.GET_USERS, async ({ request }) => {
     const url = new URL(request.url);
     const page = Number(url.searchParams.get("page")) || 1;
@@ -892,6 +892,49 @@ export const handlers = [
             ]
           }
         }
+      },
+      { status: 200 }
+    );
+  }),
+
+  // Mock API for email verification ----(17)
+  http.post("/api/user/verify-email/:token", async ({ request, params }) => {
+    const acceptLanguage = request.headers.get("Accept-Language");
+    const { token } = params;
+
+    if (!token || token === "invalid-token") {
+      return HttpResponse.json(
+        { error: "Invalid verification token." },
+        { status: 400 }
+      );
+    }
+
+    if (token === "expired-token") {
+      return HttpResponse.json(
+        { error: "Verification token has expired. Please request a new one." },
+        { status: 400 }
+      );
+    }
+
+    return HttpResponse.json(
+      {
+        message: "Email verified successfully. You can now log in.",
+        languageReceived: acceptLanguage,
+      },
+      { status: 200 }
+    );
+  }),
+
+  // Mock API for resend verification email ----(18)
+  http.post("/api/user/resend-verification", async ({ request }) => {
+    const acceptLanguage = request.headers.get("Accept-Language");
+    const body = (await request.json()) as { email?: string };
+
+    // Security: Always return success message even if email doesn't exist
+    return HttpResponse.json(
+      {
+        message: "Verification email sent.",
+        languageReceived: acceptLanguage,
       },
       { status: 200 }
     );


### PR DESCRIPTION
- Add email verification API endpoints (verify-email, resend-verification)
- Create axios and fetch API services with comprehensive tests
- Add MSW mock handlers for email verification endpoints
- Implement i18n translations for email verification (EN, AR, ML)
- Add redirect to login page after successful signup with 5s delay