### PR TITLE
feat(i18n): add password_incorrect translation for login errors

### DIFF
--- a/src/locale/i18n.ts
+++ b/src/locale/i18n.ts
@@ -64,6 +64,7 @@ i18n.use(initReactI18next).init({
             email_required: "Email is required.",
             email_invalid: "Enter a valid email address.",
             password_required: "Password is required.",
+            password_incorrect: "Password is incorrect.",
             no_active_account:
               "No active account found with the given credentials.",
             email_not_verified: "Please verify your email before logging in.",
@@ -288,6 +289,7 @@ i18n.use(initReactI18next).init({
             email_required: "ഇമെയിൽ ആവശ്യമാണ്.",
             email_invalid: "സാധുവായ ഇമെയിൽ വിലാസം നൽകുക.",
             password_required: "പാസ്‌വേഡ് ആവശ്യമാണ്.",
+            password_incorrect: "പാസ്‌വേഡ് തെറ്റാണ്.",
             no_active_account:
               "നൽകിയിട്ടുള്ള ക്രെഡൻഷ്യലുകൾ ഉപയോഗിച്ച് സജീവമായ അക്കൗണ്ട് കണ്ടെത്താനായില്ല",
             email_not_verified: "ലോഗിൻ ചെയ്യുന്നതിന് മുമ്പ് ദയവായി നിങ്ങളുടെ ഇമെയിൽ പരിശോധിക്കുക.",
@@ -496,6 +498,7 @@ i18n.use(initReactI18next).init({
             email_required: "يرجى إدخال البريد الإلكتروني.",
             email_invalid: "يرجى إدخال بريد إلكتروني صحيح.",
             password_required: "يرجى إدخال كلمة المرور.",
+            password_incorrect: "كلمة المرور غير صحيحة.",
             no_active_account:
               "لم يتم العثور على حساب نشط ببيانات الاعتماد المقدمة",
             email_not_verified: "يرجى التحقق من بريدك الإلكتروني قبل تسجيل الدخول.",

--- a/src/page/LoginPage.test.tsx
+++ b/src/page/LoginPage.test.tsx
@@ -517,6 +517,54 @@ describe("Login Page", () => {
         });
       }
     );
+
+    const passwordIncorrectTranslationTestCases = [
+      {
+        lang: "en",
+        expectedMessage: "Password is incorrect.",
+      },
+      {
+        lang: "ml",
+        expectedMessage: "പാസ്‌വേഡ് തെറ്റാണ്.",
+      },
+      {
+        lang: "ar",
+        expectedMessage: "كلمة المرور غير صحيحة.",
+      },
+    ];
+
+    it.each(passwordIncorrectTranslationTestCases)(
+      "displays translated error message for 'password_incorrect' in $lang",
+      async ({ lang, expectedMessage }) => {
+        await act(async () => {
+          await i18n.changeLanguage(lang);
+        });
+
+        mockedAxios.post.mockRejectedValue({
+          response: {
+            status: 400,
+            data: {
+              nonFieldErrors: ["password_incorrect"],
+            },
+          },
+        });
+
+        renderWithProviders(
+          <LoginPageWrapper apiService={axiosApiServiceLogin} />
+        );
+
+        await fillAndSubmitLoginForm({
+          email: "user@example.com",
+          password: "wrongpassword",
+        });
+
+        await waitFor(() => {
+          expect(screen.getByTestId("api-error")).toHaveTextContent(
+            expectedMessage
+          );
+        });
+      }
+    );
   });
 
   describe("i18n Integration", () => {


### PR DESCRIPTION
- Add password_incorrect translation key to i18n configuration
- Include translations in English, Malayalam, and Arabic
- Add comprehensive tests for password_incorrect error handling