### PR TITLE
Automatic refresh token setup

### DIFF
--- a/src/components/logout/useLogout.ts
+++ b/src/components/logout/useLogout.ts
@@ -7,6 +7,7 @@ import { resetUserState } from "../../store/userSlice";
 import { clearGlobalError } from "../../store/globalErrorSlice";
 import { ApiService } from "../../services/apiService";
 import { API_ENDPOINTS } from "../../services/apiEndpoints";
+import { stopTokenRefreshTimer } from "../../services/tokenService";
 
 export const useLogout = (apiService: ApiService) => {
   const dispatch = useDispatch();
@@ -23,6 +24,9 @@ export const useLogout = (apiService: ApiService) => {
    */
   const logout = async (): Promise<void> => {
     try {
+      // Stop the token refresh timer before logout
+      stopTokenRefreshTimer();
+
       await apiService.post(API_ENDPOINTS.LOGOUT);
       dispatch(logoutSuccess());
       dispatch(resetDashboardState());

--- a/src/page/LoginPage.tsx
+++ b/src/page/LoginPage.tsx
@@ -8,6 +8,7 @@ import { API_ENDPOINTS } from "../services/apiEndpoints";
 import { useDispatch } from "react-redux";
 import { loginSuccess } from "../store/actions";
 import { resetDashboardState } from "../store/dashboardSlice";
+import { startTokenRefreshTimer } from "../services/tokenService";
 import {
   FormWrapper,
   Form,
@@ -140,6 +141,9 @@ class LoginPage extends Component<LoginPageProps, LoginState> {
           is_superuser: response.is_superuser,
         })
       );
+
+      // Start proactive token refresh timer
+      startTokenRefreshTimer();
 
       // Reset dashboard state to ensure Recent Activity shows dropdown's first user
       this.props.dispatch(resetDashboardState());

--- a/src/services/tokenService.test.ts
+++ b/src/services/tokenService.test.ts
@@ -16,6 +16,8 @@ describe("tokenService", () => {
         username: "testuser",
         access: "mock-access-token",
         refresh: "mock-refresh-token",
+        is_staff: false,
+        is_superuser: false,
       })
     );
   });
@@ -52,6 +54,8 @@ describe("tokenService", () => {
           username: "testuser",
           access: "mock-access-token",
           refresh: "",
+          is_staff: false,
+          is_superuser: false,
         })
       );
 
@@ -155,6 +159,8 @@ describe("tokenService", () => {
           username: "testuser",
           access: "mock-access-token",
           refresh: "",
+          is_staff: false,
+          is_superuser: false,
         })
       );
 

--- a/src/services/tokenService.test.ts
+++ b/src/services/tokenService.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { refreshAccessToken } from "./tokenService";
+import { refreshAccessToken, startTokenRefreshTimer, stopTokenRefreshTimer } from "./tokenService";
 import store from "../store";
 import axios from "axios";
-import { loginSuccess } from "../store/actions";
+import { loginSuccess, logoutSuccess } from "../store/actions";
 
 vi.mock("axios");
 const mockedAxios = axios as any;
@@ -312,6 +312,170 @@ describe("tokenService", () => {
 
       // No refresh should be attempted for server errors
       expect(mockedAxios.post).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Proactive Token Refresh Timer", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+      vi.restoreAllMocks();
+    });
+
+    describe("startTokenRefreshTimer", () => {
+      it("should start a timer that refreshes tokens every 4 minutes", async () => {
+        mockedAxios.post.mockResolvedValue({
+          data: {
+            access: "refreshed-access-token",
+            refresh: "refreshed-refresh-token",
+          },
+        });
+
+        startTokenRefreshTimer();
+
+        // Fast-forward 4 minutes
+        vi.advanceTimersByTime(4 * 60 * 1000);
+
+        // Refresh should have been called
+        expect(mockedAxios.post).toHaveBeenCalledWith(
+          "/api/user/token/refresh/",
+          { refresh: "mock-refresh-token" }
+        );
+      });
+
+      it("should not start timer if no refresh token available", () => {
+        store.dispatch(
+          loginSuccess({
+            id: 1,
+            username: "testuser",
+            access: "mock-access-token",
+            refresh: "",
+            is_staff: false,
+            is_superuser: false,
+          })
+        );
+
+        startTokenRefreshTimer();
+
+        // Fast-forward 4 minutes - no refresh should be called
+        vi.advanceTimersByTime(4 * 60 * 1000);
+
+        expect(mockedAxios.post).not.toHaveBeenCalled();
+      });
+
+      it("should handle refresh failures gracefully during timer execution", async () => {
+        mockedAxios.post.mockRejectedValueOnce(new Error("Refresh failed"));
+
+        startTokenRefreshTimer();
+
+        // Fast-forward 4 minutes
+        vi.advanceTimersByTime(4 * 60 * 1000);
+
+        // Refresh should have been attempted
+        expect(mockedAxios.post).toHaveBeenCalledWith(
+          "/api/user/token/refresh/",
+          { refresh: "mock-refresh-token" }
+        );
+
+        // Timer should continue running despite failure
+        vi.advanceTimersByTime(4 * 60 * 1000);
+        expect(mockedAxios.post).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe("stopTokenRefreshTimer", () => {
+      it("should handle stopping timer when no timer is active", () => {
+        // Stop without starting - should not throw
+        expect(() => stopTokenRefreshTimer()).not.toThrow();
+      });
+
+      it("should allow restarting timer after stopping", () => {
+        mockedAxios.post.mockResolvedValue({
+          data: {
+            access: "refreshed-access-token",
+            refresh: "refreshed-refresh-token",
+          },
+        });
+
+        // Start timer
+        startTokenRefreshTimer();
+
+        // Fast-forward 4 minutes
+        vi.advanceTimersByTime(4 * 60 * 1000);
+        expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+
+        // Stop timer
+        stopTokenRefreshTimer();
+
+        // Fast-forward another 4 minutes - should not call refresh again
+        vi.advanceTimersByTime(4 * 60 * 1000);
+        expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+
+        // Restart timer
+        startTokenRefreshTimer();
+
+        // Fast-forward another 4 minutes - should call refresh again
+        vi.advanceTimersByTime(4 * 60 * 1000);
+        expect(mockedAxios.post).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe("Timer Lifecycle", () => {
+      it("should stop timer on logout", () => {
+        mockedAxios.post.mockResolvedValue({
+          data: {
+            access: "refreshed-access-token",
+            refresh: "refreshed-refresh-token",
+          },
+        });
+
+        startTokenRefreshTimer();
+
+        // Fast-forward 4 minutes
+        vi.advanceTimersByTime(4 * 60 * 1000);
+        expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+
+        // Simulate logout
+        store.dispatch(logoutSuccess());
+        stopTokenRefreshTimer();
+
+        // Fast-forward another 4 minutes - should not call refresh
+        vi.advanceTimersByTime(4 * 60 * 1000);
+        expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+      });
+
+      it("should restart timer after login", () => {
+        mockedAxios.post.mockResolvedValue({
+          data: {
+            access: "refreshed-access-token",
+            refresh: "refreshed-refresh-token",
+          },
+        });
+
+        // Start initial timer
+        startTokenRefreshTimer();
+
+        // Fast-forward 4 minutes
+        vi.advanceTimersByTime(4 * 60 * 1000);
+        expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+
+        // Stop timer (simulate logout)
+        stopTokenRefreshTimer();
+
+        // Fast-forward another 4 minutes - should not call refresh
+        vi.advanceTimersByTime(4 * 60 * 1000);
+        expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+
+        // Start new timer (simulate new login)
+        startTokenRefreshTimer();
+
+        // Fast-forward another 4 minutes - should call refresh again
+        vi.advanceTimersByTime(4 * 60 * 1000);
+        expect(mockedAxios.post).toHaveBeenCalledTimes(2);
+      });
     });
   });
 });

--- a/src/services/tokenService.ts
+++ b/src/services/tokenService.ts
@@ -37,6 +37,45 @@ export const refreshAccessToken = async (): Promise<boolean> => {
   }
 };
 
+// Global variable to store the refresh timer
+let refreshTimer: NodeJS.Timeout | null = null;
+
+/**
+ * Starts a proactive token refresh timer that refreshes tokens every 4 minutes
+ * to prevent expiration (since backend OTP expires in 5 minutes)
+ */
+export const startTokenRefreshTimer = (): void => {
+  // Clear any existing timer
+  stopTokenRefreshTimer();
+
+  const refreshToken = store.getState().auth.refreshToken;
+
+  // Only start timer if we have a refresh token
+  if (!refreshToken) {
+    return;
+  }
+
+  // Set timer to refresh every 4 minutes (240,000 milliseconds)
+  refreshTimer = setInterval(async () => {
+    try {
+      await refreshAccessToken();
+    } catch (_error) {
+      // Timer continues running even if refresh fails
+      // Errors are handled by the centralized error system
+    }
+  }, 4 * 60 * 1000); // 4 minutes
+};
+
+/**
+ * Stops the proactive token refresh timer
+ */
+export const stopTokenRefreshTimer = (): void => {
+  if (refreshTimer) {
+    clearInterval(refreshTimer);
+    refreshTimer = null;
+  }
+};
+
 // Create axios interceptor to handle token expiration
 axios.interceptors.response.use(
   (response) => response,


### PR DESCRIPTION
feat(auth): implement automatic token refresh with proactive timer
- Add proactive token refresh timer that runs every 4 minutes to prevent OTP expiration
- Integrate timer with login/logout lifecycle (starts on login, stops on logout)
- Ensure complete logout clears all tokens and stops refresh timer
- Handle refresh failures gracefully through centralized error system
- Add comprehensive test coverage for timer functionality
- Maintain backward compatibility with existing authentication flow
[ee3a29a](https://github.com/Nikhilcs36/tdd_react_typescript_vite_vitest_project/pull/281/commits/ee3a29ad9c221fb6a5b926e5f020c912dc634f88)