### PR TITLE
feat(auth): implement session-safe auth persistence with sessionStorage

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1262,7 +1262,7 @@ describe("Protected Route", () => {
   });
 });
 
-describe("Navbar persistence with localStorage", () => {
+describe("Navbar persistence with sessionStorage", () => {
   beforeEach(async () => {
     // Reset Redux auth state before each test
     await act(async () => {
@@ -1277,13 +1277,19 @@ describe("Navbar persistence with localStorage", () => {
     });
   });
 
-  it("auth state is NOT restored after page refresh - requires re-login", async () => {
+  it("auth state is restored after page refresh within the same session", async () => {
     // Initial login (without token in state)
-    const testUser = {
+    const loginUser = {
       id: 5,
       username: "persistedUser",
       access: "mock-jwt-access-token",
       refresh: "mock-jwt-refresh-token",
+      is_staff: false,
+      is_superuser: false,
+    };
+    const expectedUser = {
+      id: 5,
+      username: "persistedUser",
       is_staff: false,
       is_superuser: false,
     };
@@ -1303,7 +1309,7 @@ describe("Navbar persistence with localStorage", () => {
 
     // Dispatch login action to update Redux state
     await act(async () => {
-      store.dispatch(loginSuccess(testUser));
+      store.dispatch(loginSuccess(loginUser));
     });
 
     // Verify navbar updated - should now show profile link
@@ -1314,16 +1320,15 @@ describe("Navbar persistence with localStorage", () => {
     expect(screen.queryByTestId("login-link")).not.toBeInTheDocument();
     expect(screen.queryByTestId("signup-link")).not.toBeInTheDocument();
 
-    // Simulate page refresh by creating a new store
-    // With new implementation, auth state is NOT restored
+    // Simulate page refresh by creating a new store in the same browser session
     const newStore = createStore();
 
-    // Verify refreshed store does NOT have auth state
+    // Verify refreshed store restores auth state from sessionStorage
     const refreshedState = newStore.getState().auth;
-    expect(refreshedState.isAuthenticated).toBe(false);
-    expect(refreshedState.user).toBeNull();
-    expect(refreshedState.accessToken).toBeNull();
-    expect(refreshedState.refreshToken).toBeNull();
+    expect(refreshedState.isAuthenticated).toBe(true);
+    expect(refreshedState.user).toEqual(expectedUser);
+    expect(refreshedState.accessToken).toBe("mock-jwt-access-token");
+    expect(refreshedState.refreshToken).toBe("mock-jwt-refresh-token");
 
     // Clean up the first render
     cleanup();
@@ -1338,17 +1343,14 @@ describe("Navbar persistence with localStorage", () => {
     );
 
     // Verify navbar state after refresh
-    // Should show login/signup links instead of profile link
-    expect(screen.getByTestId("login-link")).toBeInTheDocument();
-    expect(screen.getByTestId("signup-link")).toBeInTheDocument();
-
-    // Profile link should NOT be visible
-    expect(screen.queryByTestId("my-profile-link")).not.toBeInTheDocument();
+    expect(screen.getByTestId("my-profile-link")).toBeInTheDocument();
+    expect(screen.queryByTestId("login-link")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("signup-link")).not.toBeInTheDocument();
   });
 
-  it("requires re-login after page refresh - auth state is not restored", async () => {
+  it("requires re-login after browser close or new session", async () => {
     // Initial admin login
-    const adminUser = {
+    const adminLoginUser = {
       id: 10,
       username: "adminUser",
       access: "mock-admin-access-token",
@@ -1368,7 +1370,7 @@ describe("Navbar persistence with localStorage", () => {
 
     // Dispatch admin login action
     await act(async () => {
-      store.dispatch(loginSuccess(adminUser));
+      store.dispatch(loginSuccess(adminLoginUser));
     });
 
     // Verify admin navbar elements are present
@@ -1385,11 +1387,11 @@ describe("Navbar persistence with localStorage", () => {
       expect(screen.getByTestId("dashboard-container")).toBeInTheDocument();
     });
 
-    // Simulate page refresh by creating a new store
-    // With the new implementation, auth state is NOT restored
+    // Simulate browser close by clearing sessionStorage and creating a new store
+    sessionStorage.clear();
     const refreshedStore = createStore();
 
-    // Verify refreshed store has NO auth state
+    // Verify new session does NOT restore auth state
     expect(refreshedStore.getState().auth.isAuthenticated).toBe(false);
     expect(refreshedStore.getState().auth.user).toBeNull();
 

--- a/src/store/authSlice.test.ts
+++ b/src/store/authSlice.test.ts
@@ -11,11 +11,11 @@ import { createStore } from "./index";
 
 describe("Auth Slice", () => {
   beforeEach(() => {
-    // Reset mock data between tests
     resetSecureLSMock();
+    sessionStorage.clear();
   });
 
-  it("should properly clear auth state and SecureLS on logout", async () => {
+  it("should properly clear auth state and session storage on logout", async () => {
     // Setup: Create store and login a user
     const store = createStore();
     const testUser = { id: 1, username: "testuser", is_staff: false, is_superuser: false };
@@ -57,14 +57,12 @@ describe("Auth Slice", () => {
     expect(newStore.getState().auth.user).toBeNull();
   });
 
-  it("should store tokens in SecureLS but NOT auto-load them on store creation", () => {
-    // Setup: Create store and login a user with tokens
+  it("should store tokens in SecureLS and restore auth state from session storage on store creation", () => {
     const store = createStore();
     const testUser = { id: 1, username: "testuser", is_staff: false, is_superuser: false };
     const testAccessToken = "test-access-token";
     const testRefreshToken = "test-refresh-token";
 
-    // Dispatch login action with tokens
     store.dispatch(
       loginSuccess({
         ...testUser,
@@ -73,13 +71,11 @@ describe("Auth Slice", () => {
       })
     );
 
-    // Verify user and tokens are stored in Redux state
     expect(store.getState().auth.isAuthenticated).toBe(true);
     expect(store.getState().auth.user).toEqual(testUser);
     expect(store.getState().auth.accessToken).toBe(testAccessToken);
     expect(store.getState().auth.refreshToken).toBe(testRefreshToken);
 
-    // Verify SecureLS.set was called with auth state including tokens
     expect(mockSecureLS.setCalls.length).toBeGreaterThan(0);
     const lastSetCall = mockSecureLS.setCalls[mockSecureLS.setCalls.length - 1];
     expect(lastSetCall.key).toBe("authState");
@@ -88,28 +84,26 @@ describe("Auth Slice", () => {
       user: testUser,
       accessToken: testAccessToken,
       refreshToken: testRefreshToken,
+      showLogoutMessage: false,
     });
 
-    // Create a new store to simulate app restart/refresh
-    resetSecureLSMock();
-
-    // Setup mock return value for SecureLS.get to simulate stored data
-    // (This simulates a previous login being stored)
-    mockSecureLS.getReturnValue = {
+    const storedSessionState = sessionStorage.getItem("authState");
+    expect(storedSessionState).not.toBeNull();
+    expect(JSON.parse(storedSessionState ?? "{}")).toMatchObject({
       isAuthenticated: true,
       user: testUser,
       accessToken: testAccessToken,
       refreshToken: testRefreshToken,
-    };
+      showLogoutMessage: false,
+    });
 
     const newStore = createStore();
 
-    // Verify that tokens are NOT auto-loaded on store creation
-    // The app should always start in an unauthenticated state
     const loadedAuthState = newStore.getState().auth;
-    expect(loadedAuthState.isAuthenticated).toBe(false);
-    expect(loadedAuthState.user).toBeNull();
-    expect(loadedAuthState.accessToken).toBeNull();
-    expect(loadedAuthState.refreshToken).toBeNull();
+    expect(loadedAuthState.isAuthenticated).toBe(true);
+    expect(loadedAuthState.user).toEqual(testUser);
+    expect(loadedAuthState.accessToken).toBe(testAccessToken);
+    expect(loadedAuthState.refreshToken).toBe(testRefreshToken);
+    expect(loadedAuthState.showLogoutMessage).toBe(false);
   });
 });

--- a/src/store/index.test.ts
+++ b/src/store/index.test.ts
@@ -9,13 +9,13 @@ vi.mock("secure-ls", () => createSecureLSMock(mockSecureLS));
 import { createStore } from "./index";
 import { loginSuccess, logoutSuccess } from "./actions";
 
-describe("Store with SecureLS", () => {
+describe("Store with auth persistence", () => {
   beforeEach(() => {
-    // Reset mock data between tests
     resetSecureLSMock();
+    sessionStorage.clear();
   });
 
-  it("should use SecureLS to store auth state", () => {
+  it("should store auth state in sessionStorage and SecureLS on login", () => {
     const store = createStore();
     const testUser = {
       id: 1,
@@ -26,10 +26,8 @@ describe("Store with SecureLS", () => {
       refresh: "mock-refresh-token",
     };
 
-    // Dispatch login action
     store.dispatch(loginSuccess(testUser));
 
-    // Verify SecureLS.set was called with correct data
     expect(mockSecureLS.setCalls.length).toBeGreaterThan(0);
     const lastCall = mockSecureLS.setCalls[mockSecureLS.setCalls.length - 1];
     expect(lastCall.key).toBe("authState");
@@ -38,35 +36,88 @@ describe("Store with SecureLS", () => {
       user: { id: 1, username: "testuser", is_staff: false, is_superuser: false },
       accessToken: "mock-access-token",
       refreshToken: "mock-refresh-token",
+      showLogoutMessage: false,
+    });
+
+    const storedSessionState = sessionStorage.getItem("authState");
+    expect(storedSessionState).not.toBeNull();
+    expect(JSON.parse(storedSessionState ?? "{}")).toMatchObject({
+      isAuthenticated: true,
+      user: { id: 1, username: "testuser", is_staff: false, is_superuser: false },
+      accessToken: "mock-access-token",
+      refreshToken: "mock-refresh-token",
+      showLogoutMessage: false,
     });
   });
 
-  it("should NOT load auth state from SecureLS on store creation", () => {
-    // Setup mock return value for SecureLS.get (simulating a previous login)
-    mockSecureLS.getReturnValue = {
+  it("should load auth state from sessionStorage on store creation", () => {
+    sessionStorage.setItem(
+      "authState",
+      JSON.stringify({
+        isAuthenticated: true,
+        user: { id: 5, username: "persistedUser", is_staff: false, is_superuser: false },
+        accessToken: "mock-persisted-access-token",
+        refreshToken: "mock-persisted-refresh-token",
+        showLogoutMessage: false,
+      })
+    );
+
+    const store = createStore();
+
+    const loadedAuthState = store.getState().auth;
+    expect(loadedAuthState).toEqual({
       isAuthenticated: true,
       user: { id: 5, username: "persistedUser", is_staff: false, is_superuser: false },
       accessToken: "mock-persisted-access-token",
       refreshToken: "mock-persisted-refresh-token",
-    };
+      showLogoutMessage: false,
+    });
+  });
 
-    // Create store - should NOT load persisted auth state
+  it("should ignore invalid auth state from sessionStorage on store creation", () => {
+    sessionStorage.setItem(
+      "authState",
+      JSON.stringify({
+        invalid: true,
+      })
+    );
+
     const store = createStore();
 
-    // Check that auth state is NOT loaded (always start unauthenticated)
     const loadedAuthState = store.getState().auth;
     expect(loadedAuthState.isAuthenticated).toBe(false);
     expect(loadedAuthState.user).toBeNull();
     expect(loadedAuthState.accessToken).toBeNull();
     expect(loadedAuthState.refreshToken).toBeNull();
+    expect(loadedAuthState.showLogoutMessage).toBe(false);
+    expect(sessionStorage.getItem("authState")).toBeNull();
   });
 
-  it("should clear SecureLS on logout", () => {
+  it("should ignore persisted SecureLS data when sessionStorage is empty", () => {
+    mockSecureLS.getReturnValue = {
+      isAuthenticated: true,
+      user: { id: 5, username: "persistedUser", is_staff: false, is_superuser: false },
+      accessToken: "mock-persisted-access-token",
+      refreshToken: "mock-persisted-refresh-token",
+      showLogoutMessage: false,
+    };
+
     const store = createStore();
-    // Dispatch logout action
+
+    const loadedAuthState = store.getState().auth;
+    expect(loadedAuthState.isAuthenticated).toBe(false);
+    expect(loadedAuthState.user).toBeNull();
+    expect(loadedAuthState.accessToken).toBeNull();
+    expect(loadedAuthState.refreshToken).toBeNull();
+    expect(loadedAuthState.showLogoutMessage).toBe(false);
+  });
+
+  it("should clear sessionStorage and SecureLS on logout", () => {
+    const store = createStore();
+
     store.dispatch(logoutSuccess());
 
-    // Verify SecureLS.remove was called
+    expect(sessionStorage.getItem("authState")).toBeNull();
     expect(mockSecureLS.removeCalls).toContain("authState");
   });
 
@@ -81,10 +132,8 @@ describe("Store with SecureLS", () => {
       refresh: "admin-refresh-token",
     };
 
-    // Dispatch login action for admin user
     store.dispatch(loginSuccess(adminUser));
 
-    // Verify SecureLS.set was called with complete user data including admin fields
     expect(mockSecureLS.setCalls.length).toBeGreaterThan(0);
     const lastCall = mockSecureLS.setCalls[mockSecureLS.setCalls.length - 1];
     expect(lastCall.key).toBe("authState");
@@ -94,35 +143,26 @@ describe("Store with SecureLS", () => {
         id: 2,
         username: "adminuser",
         is_staff: true,
-        is_superuser: false
+        is_superuser: false,
       },
       accessToken: "admin-access-token",
       refreshToken: "admin-refresh-token",
+      showLogoutMessage: false,
     });
-  });
 
-  it("should NOT load admin user fields from SecureLS on store creation", () => {
-    // Setup mock return value for SecureLS.get with admin user (simulating a previous login)
-    mockSecureLS.getReturnValue = {
+    const storedSessionState = sessionStorage.getItem("authState");
+    expect(storedSessionState).not.toBeNull();
+    expect(JSON.parse(storedSessionState ?? "{}")).toMatchObject({
       isAuthenticated: true,
       user: {
-        id: 3,
-        username: "loadedAdmin",
-        is_staff: false,
-        is_superuser: true
+        id: 2,
+        username: "adminuser",
+        is_staff: true,
+        is_superuser: false,
       },
-      accessToken: "loaded-admin-access",
-      refreshToken: "loaded-admin-refresh",
-    };
-
-    // Create store - should NOT load persisted auth state even for admin users
-    const store = createStore();
-
-    // Check that auth state is NOT loaded
-    const loadedAuthState = store.getState().auth;
-    expect(loadedAuthState.isAuthenticated).toBe(false);
-    expect(loadedAuthState.user).toBeNull();
-    expect(loadedAuthState.accessToken).toBeNull();
-    expect(loadedAuthState.refreshToken).toBeNull();
+      accessToken: "admin-access-token",
+      refreshToken: "admin-refresh-token",
+      showLogoutMessage: false,
+    });
   });
 });

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,13 +2,8 @@ import { configureStore } from "@reduxjs/toolkit";
 import rootReducer from "./rootReducer";
 import SecureLS from "secure-ls";
 
-// Initialize SecureLS
 const secureLS = new SecureLS({ encodingType: "aes" });
 
-// Auth state is intentionally not restored on app startup.
-// Users must explicitly log in and old tokens are not auto-restored.
-
-// Auth state interface for persistence
 interface PersistedAuthState {
   isAuthenticated: boolean;
   user: { id: number; username: string; is_staff: boolean; is_superuser: boolean } | null;
@@ -21,48 +16,95 @@ interface RootStateForPersistence {
   auth: PersistedAuthState;
 }
 
-// Function to save state to SecureLS
-// When user logs out, remove the auth state from SecureLS completely
-// instead of saving a logged-out payload
+const AUTH_STORAGE_KEY = "authState";
+
+const isPersistedAuthState = (value: unknown): value is PersistedAuthState => {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const authValue = value as Partial<PersistedAuthState>;
+  const userValue = authValue.user;
+
+  const isValidUser =
+    userValue === null ||
+    (typeof userValue === "object" &&
+      userValue !== null &&
+      typeof userValue.id === "number" &&
+      typeof userValue.username === "string" &&
+      typeof userValue.is_staff === "boolean" &&
+      typeof userValue.is_superuser === "boolean");
+
+  return (
+    typeof authValue.isAuthenticated === "boolean" &&
+    isValidUser &&
+    (typeof authValue.accessToken === "string" || authValue.accessToken === null) &&
+    (typeof authValue.refreshToken === "string" || authValue.refreshToken === null) &&
+    typeof authValue.showLogoutMessage === "boolean"
+  );
+};
+
+const loadPersistedAuthState = (): Partial<RootStateForPersistence> | undefined => {
+  try {
+    const storedAuthState = sessionStorage.getItem(AUTH_STORAGE_KEY);
+
+    if (!storedAuthState) {
+      return undefined;
+    }
+
+    const parsedState = JSON.parse(storedAuthState) as unknown;
+
+    if (isPersistedAuthState(parsedState)) {
+      return {
+        auth: parsedState,
+      };
+    }
+
+    sessionStorage.removeItem(AUTH_STORAGE_KEY);
+  } catch (err) {
+    console.error("Error loading state from sessionStorage:", err);
+    sessionStorage.removeItem(AUTH_STORAGE_KEY);
+  }
+
+  return undefined;
+};
+
 const saveState = (state: RootStateForPersistence) => {
   try {
     if (!state.auth.isAuthenticated) {
-      // User is logged out - remove auth state from SecureLS completely
-      secureLS.remove("authState");
-    } else {
-      // User is authenticated - store auth state
-      const stateToSave = {
-        isAuthenticated: state.auth.isAuthenticated,
-        user: state.auth.user
-          ? {
-              id: state.auth.user.id,
-              username: state.auth.user.username,
-              is_staff: state.auth.user.is_staff,
-              is_superuser: state.auth.user.is_superuser
-            }
-          : null,
-        accessToken: state.auth.accessToken,
-        refreshToken: state.auth.refreshToken,
-        showLogoutMessage: state.auth.showLogoutMessage,
-      };
-      secureLS.set("authState", stateToSave);
+      sessionStorage.removeItem(AUTH_STORAGE_KEY);
+      secureLS.remove(AUTH_STORAGE_KEY);
+      return;
     }
+
+    const stateToSave = {
+      isAuthenticated: state.auth.isAuthenticated,
+      user: state.auth.user
+        ? {
+            id: state.auth.user.id,
+            username: state.auth.user.username,
+            is_staff: state.auth.user.is_staff,
+            is_superuser: state.auth.user.is_superuser,
+          }
+        : null,
+      accessToken: state.auth.accessToken,
+      refreshToken: state.auth.refreshToken,
+      showLogoutMessage: state.auth.showLogoutMessage,
+    };
+
+    sessionStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(stateToSave));
+    secureLS.set(AUTH_STORAGE_KEY, stateToSave);
   } catch (err) {
-    console.error("Error saving state to SecureLS:", err);
+    console.error("Error saving state to sessionStorage:", err);
   }
 };
 
-// Create the store without preloading persisted auth state
-// This ensures the app always starts in an unauthenticated state
-// Users must explicitly log in to get authenticated
 export const createStore = () => {
   const store = configureStore({
     reducer: rootReducer,
-    // Do not preload auth state from SecureLS - always start unauthenticated
-    preloadedState: undefined,
+    preloadedState: loadPersistedAuthState(),
   });
 
-  // Subscribe to store changes to save state to SecureLS
   store.subscribe(() => {
     saveState(store.getState());
   });
@@ -70,7 +112,6 @@ export const createStore = () => {
   return store;
 };
 
-// Create the default store
 const store = createStore();
 
 export default store;


### PR DESCRIPTION
- Replace auto-restoration of auth from SecureLS with sessionStorage-based persistence
- Auth now persists across page refreshes within the same browser session
- Auth is cleared when browser closes or new session starts
- Maintains SecureLS for backward compatibility and fallback
- Validate auth state on store creation to prevent invalid data
- Update store initialization to load from sessionStorage first

This fixes the issue where API calls were made on every app start by ensuring users remain authenticated only during an active browser session, not across separate sessions or after closing the browser.