### PR TITLE
feat: make API proxy target configurable for Docker and local dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# API Proxy Target
+# For local development (backend running on host machine on port 8000)
+VITE_API_PROXY_TARGET=http://localhost:8000

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
+.env
 dist
 dist-ssr
 *.local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
     environment:
       # Set Node environment
       - NODE_ENV=development
+      # Override API proxy target to use Docker service hostname
+      - VITE_API_PROXY_TARGET=http://backend:8000
     networks:
       - tdd-network
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,11 +24,11 @@ export default defineConfig({
     server: {
       proxy: {
         '/api': {
-          target: 'http://backend:8000/',
+          target: process.env.VITE_API_PROXY_TARGET || 'http://localhost:8000',
           changeOrigin: true,
         },
         '/media': {
-          target: 'http://backend:8000/',
+          target: process.env.VITE_API_PROXY_TARGET || 'http://localhost:8000',
           changeOrigin: true,
         },
       },


### PR DESCRIPTION
- Replace hardcoded Docker hostname in Vite proxy with env variable
- Add VITE_API_PROXY_TARGET=http://backend:8000 to docker-compose.yml
- Add .env to .gitignore to prevent accidental commits
- Create .env.example documenting the required variable
- Fall back to http://localhost:8000 for local development