### PR TITLE
Rsa implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The TDD approach was particularly valuable for building the Login Tracking Dashb
 - **Role-based Access**: Admin-only routes protected with `ProtectedRoute` component
 - **Token Management**: Automatic token refresh via axios interceptors on 401 responses
 - **Secure Token Storage**: Tokens stored in Redux state (in-memory) with encrypted localStorage backup via Secure-LS
+- **RSA-OAEP Password Encryption**: Login passwords encrypted with 2048-bit RSA public key using the Web Crypto API (SubtleCrypto) before transmission over the network
 - **Session Persistence**: Auth state persisted across page refreshes using sessionStorage
 - **Automatic Token Invalidation**: Tokens cleared on logout with Redux state cleanup
 - **Axios Interceptors**: Language-aware API headers (Accept-Language) and authorization header management
@@ -188,6 +189,7 @@ The TDD approach was particularly valuable for building the Login Tracking Dashb
 
 ### Security
 - **Secure-LS** - Encrypted localStorage for sensitive data
+- **Web Crypto API** - Browser-native RSA-OAEP encryption (SubtleCrypto)
 
 ### Deployment & Infrastructure
 - **Docker** - Containerized development environment
@@ -364,6 +366,8 @@ npm run dev
 │   │   ├── authorization.ts       # User authorization utilities
 │   │   ├── dateUtils.ts           # Date formatting utilities
 │   │   ├── djangoErrorHandler.ts  # Django error response parser
+│   │   ├── encryption.ts          # RSA-OAEP public key encryption (Web Crypto API)
+│   │   ├── encryption.test.ts     # Encryption utility tests
 │   │   └── validationRules.ts     # Form validation rules
 │   ├── App.tsx                    # Root application with routing
 │   ├── App.test.tsx               # Root application tests
@@ -393,7 +397,8 @@ The frontend communicates with the [backend REST API](https://github.com/Nikhilc
 ### API Endpoints Consumed
 
 #### Authentication Endpoints
-- `POST /api/user/token/` - Login
+- `POST /api/user/token/` - Login (accepts `password` or `encrypted_password`)
+- `GET /api/user/public-key/` - Fetch RSA 2048-bit public key for password encryption
 - `POST /api/user/token/refresh/` - Refresh token
 - `POST /api/user/create/` - Register
 - `GET /api/user/logout/` - Logout
@@ -425,12 +430,15 @@ The frontend communicates with the [backend REST API](https://github.com/Nikhilc
 
 ### Authentication Flow
 
-1. User submits credentials via login form
-2. Backend returns JWT access and refresh tokens
-3. Tokens are stored in Redux state and encrypted localStorage
-4. Axios interceptor attaches `Authorization: JWT <token>` header to all requests
-5. On 401 response, interceptor attempts token refresh
-6. On logout, tokens are cleared from Redux and storage
+1. Login form fetches RSA 2048-bit public key from `/api/user/public-key/`
+2. Password is encrypted with RSA-OAEP SHA-256 using the browser's Web Crypto API
+3. Encrypted password (hex-encoded) is sent in place of the plaintext password
+4. Backend validates credentials (supports both `encrypted_password` and legacy `password`)
+5. On success, JWT access and refresh tokens are returned
+6. Tokens are stored in Redux state and encrypted localStorage via Secure-LS
+7. Axios interceptor attaches `Authorization: JWT <token>` header to all requests
+8. On 401 response, interceptor attempts token refresh
+9. On logout, tokens are cleared from Redux and storage
 
 ## Testing
 

--- a/src/page/LoginPage.test.tsx
+++ b/src/page/LoginPage.test.tsx
@@ -19,6 +19,8 @@ import store from "../store";
 import { logoutSuccess } from "../store/actions";
 import { resetDashboardState } from "../store/dashboardSlice";
 import { API_ENDPOINTS } from "../services/apiEndpoints";
+import { http, HttpResponse } from "msw";
+import { server } from "../tests/mocks/server";
 
 vi.mock("axios");
 const mockedAxios = vi.mocked(axios, { deep: true });
@@ -165,13 +167,20 @@ describe("Login Page", () => {
 
       await fillAndSubmitLoginForm(validCredentials);
 
+      // The handleSubmit now encrypts the password before sending
+      // So the body should contain encrypted_password instead of plaintext password
       expect(mockedAxios.post).toHaveBeenCalledWith(
         API_ENDPOINTS.LOGIN,
-        validCredentials,
+        expect.objectContaining({
+          email: "user@example.com",
+          encrypted_password: expect.any(String),
+        }),
         expect.objectContaining({
           headers: { "Accept-Language": "en" },
         })
       );
+      // Ensure plaintext password is NOT sent
+      expect(mockedAxios.post.mock.calls[0][1]).not.toHaveProperty("password");
     });
 
     it("disables button during submission (MSW integration test)", async () => {
@@ -319,6 +328,19 @@ describe("Login Page", () => {
   });
 
   describe("Login Page - Authentication Failure", () => {
+    beforeEach(() => {
+      // Override public key endpoint to return 500 so the test falls back to plaintext password
+      // This is needed because handleSubmit now tries to encrypt the password first
+      server.use(
+        http.get(API_ENDPOINTS.PUBLIC_KEY, async () => {
+          return HttpResponse.json(
+            { error: "Public key unavailable" },
+            { status: 500 }
+          );
+        })
+      );
+    });
+
     it("displays authentication fail message", async () => {
       renderWithProviders(
         <LoginPageWrapper apiService={fetchApiServiceLogin} />
@@ -779,6 +801,19 @@ describe("Login Page", () => {
   });
 
   describe("Forgot Password - Inline Flow", () => {
+    beforeEach(() => {
+      // Override public key endpoint to return 500 so the test falls back to plaintext password
+      // This is needed because handleSubmit now tries to encrypt the password first
+      server.use(
+        http.get(API_ENDPOINTS.PUBLIC_KEY, async () => {
+          return HttpResponse.json(
+            { error: "Public key unavailable" },
+            { status: 500 }
+          );
+        })
+      );
+    });
+
     it("shows forgot password link after login failure", async () => {
       renderWithProviders(
         <LoginPageWrapper apiService={fetchApiServiceLogin} />

--- a/src/page/LoginPage.tsx
+++ b/src/page/LoginPage.tsx
@@ -1,6 +1,7 @@
 import { Component } from "react";
 import { ApiService } from "../services/apiService";
 import { LoginRequestBody, validateLogin } from "../utils/validationRules";
+import { encryptWithPublicKey, fetchPublicKey } from "../utils/encryption";
 import { withTranslation, WithTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { API_ENDPOINTS } from "../services/apiEndpoints";
@@ -141,12 +142,21 @@ class LoginPage extends Component<LoginPageProps, LoginState> {
 
     try {
       const { email, password } = this.state;
+      let requestBody: LoginRequestBody = { email, password };
+
+      // Attempt to encrypt the password using the backend's public key
+      try {
+        const publicKey = await fetchPublicKey();
+        const encryptedPassword = await encryptWithPublicKey(publicKey, password);
+        requestBody = { email, encrypted_password: encryptedPassword };
+      } catch (encryptionError) {
+        // Fallback to plaintext password if encryption fails
+        console.warn("Password encryption failed, falling back to plaintext:", encryptionError);
+      }
+
       const response = await this.props.apiService.post<LoginResponse>(
         API_ENDPOINTS.LOGIN,
-        {
-          email,
-          password,
-        }
+        requestBody
       );
 
       // Dispatch loginSuccess action with id, username, access, refresh, and role fields

--- a/src/services/apiEndpoints.ts
+++ b/src/services/apiEndpoints.ts
@@ -2,6 +2,7 @@
 export const API_ENDPOINTS = {
   SIGNUP: "/api/user/create/",
   LOGIN: "/api/user/token/",
+  PUBLIC_KEY: "/api/user/public-key/",
   ME: "/api/user/me/",
   TOKEN_REFRESH: "/api/user/token/refresh/",
   LOGOUT: "/api/user/logout/",

--- a/src/tests/mocks/handlers.ts
+++ b/src/tests/mocks/handlers.ts
@@ -224,7 +224,24 @@ export const handlers = [
     return HttpResponse.json(currentUser, { status: 200 });
   }),
 
-  // Mock API for user login (msw) ----(5)
+  // Mock API for public key retrieval (msw) ----(5)
+  http.get(API_ENDPOINTS.PUBLIC_KEY, async ({ request }) => {
+    const acceptLanguage = request.headers.get("Accept-Language");
+    return HttpResponse.json({
+      public_key: `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqWkeynxt+9WEI88BSdxX
+5cCNHv8Z1A88wB1QGu9Qxv4q0waJ82/4DvZ8mhi9e7zOuepiuAPSpcZIefdxuUab
+VpioiV8LvFJAW1mnnRESNycQ5gMfI/piI5BaeHyWhEw7t/8coUrEsIst99v3GW7z
+kaATt6w7hA0HDQiFPcXwaUD5QfiGbcfxc7hyaMjIXgjL83Ff6XzVVpiFc7e5Up9e
+vbqiHVaJ+CZB6X429gQCJc18AST6cscfFvGDknMWJ7f/7JpcNbAR3Ww32z+MjVwG
+FiFHDnq0XqBiacU8fk3NdlY8TqjxR8e9GaTTgx+UMvfR2itgEuKGfd2oImkMxC4L
+5QIDAQAB
+-----END PUBLIC KEY-----`,
+      languageReceived: acceptLanguage,
+    });
+  }),
+
+  // Mock API for user login (msw) ----(6)
   http.post(API_ENDPOINTS.LOGIN, async ({ request }) => {
     const acceptLanguage = request.headers.get("Accept-Language");
     const body = (await request.json()) as LoginRequestBody;
@@ -240,12 +257,39 @@ export const handlers = [
       return HttpResponse.json(djangoValidationErrors, { status: 400 });
     }
 
-    // Handle empty fields (Django returns field-specific errors)
-    if (!body.email || !body.password) {
-      const emptyFieldErrors: Record<string, string[]> = {};
-      if (!body.email) emptyFieldErrors.email = ["email_required"];
-      if (!body.password) emptyFieldErrors.password = ["password_required"];
-      return HttpResponse.json(emptyFieldErrors, { status: 400 });
+    // Handle empty fields
+    if (!body.email) {
+      return HttpResponse.json({ email: ["email_required"] }, { status: 400 });
+    }
+
+    // Handle encrypted_password flow - if encrypted_password is provided, treat as valid for user@example.com
+    if (body.encrypted_password && !body.password) {
+      if (body.email !== "user@example.com") {
+        return HttpResponse.json(
+          {
+            non_field_errors: ["no_active_account"],
+            languageReceived: acceptLanguage,
+          },
+          { status: 400 }
+        );
+      }
+      // Successful login with encrypted password
+      return HttpResponse.json(
+        {
+          id: 1,
+          username: "testuser",
+          email: body.email,
+          access: "mock-access-token",
+          refresh: "mock-refresh-token",
+          languageReceived: acceptLanguage,
+        },
+        { status: 200 }
+      );
+    }
+
+    // Handle plaintext password flow
+    if (!body.password) {
+      return HttpResponse.json({ password: ["password_required"] }, { status: 400 });
     }
 
     // Mock database of valid users (could be moved to a separate file)

--- a/src/utils/encryption.test.ts
+++ b/src/utils/encryption.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { encryptWithPublicKey } from "./encryption";
+
+// A valid RSA public key in PEM format (2048-bit) for testing
+// Generated with Node.js crypto.generateKeyPairSync
+const validPublicKeyPem = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqWkeynxt+9WEI88BSdxX
+5cCNHv8Z1A88wB1QGu9Qxv4q0waJ82/4DvZ8mhi9e7zOuepiuAPSpcZIefdxuUab
+VpioiV8LvFJAW1mnnRESNycQ5gMfI/piI5BaeHyWhEw7t/8coUrEsIst99v3GW7z
+kaATt6w7hA0HDQiFPcXwaUD5QfiGbcfxc7hyaMjIXgjL83Ff6XzVVpiFc7e5Up9e
+vbqiHVaJ+CZB6X429gQCJc18AST6cscfFvGDknMWJ7f/7JpcNbAR3Ww32z+MjVwG
+FiFHDnq0XqBiacU8fk3NdlY8TqjxR8e9GaTTgx+UMvfR2itgEuKGfd2oImkMxC4L
+5QIDAQAB
+-----END PUBLIC KEY-----`;
+
+describe("encryptWithPublicKey", () => {
+  it("returns a hex-encoded string when given valid PEM key and data", async () => {
+    const ciphertext = await encryptWithPublicKey(validPublicKeyPem, "testpassword");
+    expect(typeof ciphertext).toBe("string");
+    expect(ciphertext.length).toBeGreaterThan(0);
+    // Hex pattern check (only 0-9 and a-f)
+    expect(/^[0-9a-f]+$/i.test(ciphertext)).toBe(true);
+  });
+
+  it("returns an even-length hex string (valid hex format)", async () => {
+    const ciphertext = await encryptWithPublicKey(validPublicKeyPem, "testpassword");
+    // Each byte is 2 hex characters, so length must be even
+    expect(ciphertext.length % 2).toBe(0);
+  });
+
+  it("produces ciphertext of expected length for 2048-bit RSA (256 bytes = 512 hex chars)", async () => {
+    const ciphertext = await encryptWithPublicKey(validPublicKeyPem, "testpassword");
+    // RSA-OAEP with 2048-bit key produces 256-byte ciphertext
+    // 256 bytes = 512 hex characters
+    expect(ciphertext.length).toBe(512);
+  });
+
+  it("produces different ciphertext for different data (RSA-OAEP is probabilistic)", async () => {
+    const cipher1 = await encryptWithPublicKey(validPublicKeyPem, "password1");
+    const cipher2 = await encryptWithPublicKey(validPublicKeyPem, "password2");
+    expect(cipher1).not.toBe(cipher2);
+  });
+
+  it("produces different ciphertext each time for the same data (OAEP uses random salt)", async () => {
+    const cipher1 = await encryptWithPublicKey(validPublicKeyPem, "samepassword");
+    const cipher2 = await encryptWithPublicKey(validPublicKeyPem, "samepassword");
+    expect(cipher1).not.toBe(cipher2);
+  });
+
+  it("throws an error when given an invalid PEM key", async () => {
+    await expect(
+      encryptWithPublicKey("invalid-pem-key", "testpassword")
+    ).rejects.toThrow();
+  });
+
+  it("throws an error when given empty data", async () => {
+    await expect(
+      encryptWithPublicKey(validPublicKeyPem, "")
+    ).rejects.toThrow();
+  });
+});

--- a/src/utils/encryption.ts
+++ b/src/utils/encryption.ts
@@ -1,0 +1,74 @@
+import { API_ENDPOINTS } from "../services/apiEndpoints";
+
+/**
+ * Encrypts data using RSA-OAEP with SHA-256.
+ * Uses the Web Crypto API (SubtleCrypto) available in modern browsers.
+ *
+ * @param publicKeyPem - The RSA public key in PEM format (including -----BEGIN PUBLIC KEY----- and -----END PUBLIC KEY-----)
+ * @param data - The plaintext string to encrypt
+ * @returns The encrypted data as a hex-encoded string
+ * @throws If key import or encryption fails
+ */
+export async function encryptWithPublicKey(
+  publicKeyPem: string,
+  data: string
+): Promise<string> {
+  if (!data) {
+    throw new Error("Data to encrypt cannot be empty");
+  }
+
+  // 1. Convert PEM string to ArrayBuffer (base64 decode between header/footer)
+  const pemHeader = "-----BEGIN PUBLIC KEY-----";
+  const pemFooter = "-----END PUBLIC KEY-----";
+  const pemContents = publicKeyPem
+    .replace(pemHeader, "")
+    .replace(pemFooter, "")
+    .replace(/\s/g, ""); // Remove all whitespace (newlines, spaces, tabs)
+
+  // Decode base64 to binary
+  const binaryDer = Uint8Array.from(atob(pemContents), (c) => c.charCodeAt(0));
+
+  // 2. Import the RSA public key using the Web Crypto API
+  const publicKey = await crypto.subtle.importKey(
+    "spki", // SubjectPublicKeyInfo format
+    binaryDer.buffer,
+    {
+      name: "RSA-OAEP",
+      hash: { name: "SHA-256" },
+    },
+    false, // Not extractable
+    ["encrypt"]
+  );
+
+  // 3. Encrypt the data
+  const encodedData = new TextEncoder().encode(data);
+  const encryptedBuffer = await crypto.subtle.encrypt(
+    {
+      name: "RSA-OAEP",
+    },
+    publicKey,
+    encodedData
+  );
+
+  // 4. Convert to hex string (backend expects hex format for bytes.fromhex())
+  const encryptedArray = new Uint8Array(encryptedBuffer);
+  const hexCiphertext = Array.from(encryptedArray, (byte) =>
+    byte.toString(16).padStart(2, "0")
+  ).join("");
+
+  return hexCiphertext;
+}
+
+/**
+ * Fetches the RSA public key from the backend API.
+ * @returns The PEM-encoded public key string
+ * @throws If the fetch fails or the key is invalid
+ */
+export async function fetchPublicKey(): Promise<string> {
+  const response = await fetch(API_ENDPOINTS.PUBLIC_KEY);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch public key: ${response.status}`);
+  }
+  const data = await response.json();
+  return data.public_key;
+}

--- a/src/utils/encryption.ts
+++ b/src/utils/encryption.ts
@@ -31,7 +31,7 @@ export async function encryptWithPublicKey(
   // 2. Import the RSA public key using the Web Crypto API
   const publicKey = await crypto.subtle.importKey(
     "spki", // SubjectPublicKeyInfo format
-    binaryDer.buffer,
+    binaryDer,
     {
       name: "RSA-OAEP",
       hash: { name: "SHA-256" },

--- a/src/utils/validationRules.ts
+++ b/src/utils/validationRules.ts
@@ -7,7 +7,8 @@ export type SignUpRequestBody = {
 
 export type LoginRequestBody = {
   email: string;
-  password: string;
+  password?: string;
+  encrypted_password?: string;
 };
 
 export type UserUpdateRequestBody = {
@@ -78,7 +79,8 @@ export const validateLogin = (values: LoginRequestBody) => {
     errors.email = "email_invalid";
   }
 
-  if (!values.password) {
+  // Password is required only if encrypted_password is not provided
+  if (!values.password && !values.encrypted_password) {
     errors.password = "password_required";
   }
 


### PR DESCRIPTION
feat: implement RSA-OAEP login credential encryption on frontend

 - Add encryptWithPublicKey() utility using Web Crypto API (SubtleCrypto)
    - Imports PEM public key as RSA-OAEP with SHA-256
    - Encrypts password and returns hex-encoded ciphertext
    - Provides fetchPublicKey() to retrieve backend's public key

- Update LoginPage handleSubmit to encrypt password before sending
  - Fetches public key from /api/user/public-key/
  - Sends encrypted_password (hex) instead of plaintext password
  - Falls back to plaintext if encryption fails (backward compatible)

- Add PUBLIC_KEY endpoint to centralized apiEndpoints

- Update LoginRequestBody type to support both password and encrypted_password

- Add MSW mock handler for public key endpoint

- Write 7 tests for encryption utility:
  - hex-encoded output format
  - even-length hex string validation
  - 512-char length for 2048-bit RSA ciphertext
  - probabilistic encryption (different ciphertext for different/same data)
  - error handling for invalid key and empty data (https://github.com/Nikhilcs36/tdd_react_typescript_vite_vitest_project/pull/314/commits/dc594b3967abd771bcb09e31a3d5a75be041efa2)
* [update readme with RSA](https://github.com/Nikhilcs36/tdd_react_typescript_vite_vitest_project/pull/314/commits/3caa9b42fdd38ba7bd03d6a304eada0c5911104a)