### PR TITLE
setup download summary

### DIFF
--- a/src/components/dashboard/DashboardContainer.test.tsx
+++ b/src/components/dashboard/DashboardContainer.test.tsx
@@ -135,6 +135,13 @@ vi.mock('./ChartModeToggle', () => ({
   default: () => <div data-testid="chart-mode-toggle">Chart Mode Toggle</div>,
 }));
 
+vi.mock('./ReportDownloadButton', () => ({
+  default: ({ isAdmin }: { isAdmin: boolean }) => (
+    <div data-testid="report-download-button">
+      {isAdmin ? 'Download Report (Admin)' : 'Download Report'}
+    </div>
+  ),
+}));
 
 describe('DashboardContainer', () => {
   // Basic rendering tests (fast, lightweight)

--- a/src/components/dashboard/DashboardContainer.tsx
+++ b/src/components/dashboard/DashboardContainer.tsx
@@ -17,6 +17,7 @@ import DashboardUserList from './DashboardUserList';
 import DateRangePicker from './DateRangePicker';
 import UserSelectorDropdown from './UserSelectorDropdown';
 import ChartModeToggle from './ChartModeToggle';
+import ReportDownloadButton from './ReportDownloadButton';
 import {
   DashboardContainerWrapper,
   DashboardGrid,
@@ -37,6 +38,7 @@ const PageHeader = tw.div`mb-8`;
 const Title = tw.h1`text-3xl font-bold text-gray-900 dark:text-dark-text mb-2`;
 const Subtitle = tw.p`text-gray-600 dark:text-gray-300`;
 
+const DownloadSection = tw.div`mt-6 mb-4`;
 
 interface DashboardContainerProps {
   userId?: number;
@@ -128,7 +130,6 @@ const DashboardContainer: React.FC<DashboardContainerProps> = ({ userId }) => {
         const targetUserId = isAdmin() ? (dashboardState.selectedDashboardUserId || userId) : currentUserId;
         const startDate = dashboardState.startDate || undefined;
         const endDate = dashboardState.endDate || undefined;
-
         const response = await getUserStats(targetUserId, startDate, endDate);
         setUserStats(response);
       } catch (_err: unknown) {
@@ -158,7 +159,6 @@ const DashboardContainer: React.FC<DashboardContainerProps> = ({ userId }) => {
         const targetUserId = isAdmin() ? (dashboardState.selectedDashboardUserId || userId) : currentUserId;
         const startDate = dashboardState.startDate || undefined;
         const endDate = dashboardState.endDate || undefined;
-
         // Use maximum page size (100) to get as many records as possible initially
         const response = await getLoginActivity(1, 100, targetUserId, startDate, endDate);
         setLoginActivity(response);
@@ -562,6 +562,11 @@ const DashboardContainer: React.FC<DashboardContainerProps> = ({ userId }) => {
               </AdminOverviewCard>
             </>
           )}
+
+          {/* Download Report Button - Show at the bottom for all authenticated users */}
+          <DownloadSection data-testid="report-download-section">
+            <ReportDownloadButton isAdmin={isAdmin()} />
+          </DownloadSection>
         </DashboardContainerWrapper>
       </ContentWrapper>
     </PageContainer>

--- a/src/components/dashboard/ReportDownloadButton.test.tsx
+++ b/src/components/dashboard/ReportDownloadButton.test.tsx
@@ -1,0 +1,1000 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { I18nextProvider } from 'react-i18next';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import i18n from '../../locale/i18n';
+import ReportDownloadButton from './ReportDownloadButton';
+import dashboardReducer, { DashboardState } from '../../store/dashboardSlice';
+import authReducer, { AuthState } from '../../store/authSlice';
+import globalErrorReducer from '../../store/globalErrorSlice';
+import * as loginTrackingService from '../../services/loginTrackingService';
+
+// Mock the downloadReport service
+vi.mock('../../services/loginTrackingService', async () => {
+  const actual = await vi.importActual('../../services/loginTrackingService');
+  return {
+    ...actual,
+    downloadReport: vi.fn(),
+  };
+});
+
+const createMockStore = (dashboardState: Partial<DashboardState> = {}, authState: Partial<AuthState> = {}) => {
+  const defaultDashboardState: DashboardState = {
+    activeFilter: 'all',
+    selectedUserIds: [],
+    datePreset: '30days',
+    startDate: null,
+    endDate: null,
+    isLoading: false,
+    error: null,
+    chartMode: 'individual',
+    selectedDashboardUserId: null,
+    currentDropdownUsers: [],
+    ...dashboardState,
+  };
+
+  const defaultAuthState: AuthState = {
+    user: { id: 1, username: 'testuser', is_staff: false, is_superuser: false },
+    accessToken: 'fake-token',
+    refreshToken: 'fake-refresh-token',
+    isAuthenticated: true,
+    showLogoutMessage: false,
+    ...authState,
+  };
+
+  return configureStore({
+    reducer: {
+      dashboard: dashboardReducer,
+      auth: authReducer,
+      globalError: globalErrorReducer,
+    },
+    preloadedState: {
+      dashboard: defaultDashboardState,
+      auth: defaultAuthState,
+    },
+  });
+};
+
+const renderWithProviders = (component: React.ReactElement, dashboardState = {}, authState = {}) => {
+  const store = createMockStore(dashboardState, authState);
+  return { ...render(
+    <Provider store={store}>
+      <I18nextProvider i18n={i18n}>
+        {component}
+      </I18nextProvider>
+    </Provider>
+  ), store };
+};
+
+describe('ReportDownloadButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Ensure document starts without dark class
+    document.documentElement.classList.remove('dark');
+  });
+
+  afterEach(() => {
+    // Clean up dark class after each test
+    document.documentElement.classList.remove('dark');
+  });
+
+  describe('Regular User', () => {
+    it('should render download button for regular user', () => {
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={false} />,
+        {},
+        { user: { id: 1, username: 'testuser', is_staff: false, is_superuser: false } }
+      );
+
+      expect(screen.getByTestId('report-download-button')).toBeInTheDocument();
+      expect(screen.getByText('Download Report')).toBeInTheDocument();
+    });
+
+    it('should call downloadReport with individual mode when clicked for regular user', async () => {
+      vi.mocked(loginTrackingService.downloadReport).mockResolvedValue({
+        blob: new Blob(['test']),
+        filename: 'login_report_testuser_individual_20260101_120000.xlsx',
+      });
+
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={false} />,
+        {},
+        { user: { id: 1, username: 'testuser', is_staff: false, is_superuser: false } }
+      );
+
+      fireEvent.click(screen.getByTestId('report-download-button'));
+
+      await waitFor(() => {
+        expect(loginTrackingService.downloadReport).toHaveBeenCalledWith({
+          mode: 'individual',
+        });
+      });
+    });
+
+    it('should pass startDate and endDate from dashboard state', async () => {
+      vi.mocked(loginTrackingService.downloadReport).mockResolvedValue({
+        blob: new Blob(['test']),
+        filename: 'login_report_testuser_individual_20260101_120000.xlsx',
+      });
+
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={false} />,
+        { startDate: '2025-12-01', endDate: '2025-12-31' },
+        { user: { id: 1, username: 'testuser', is_staff: false, is_superuser: false } }
+      );
+
+      fireEvent.click(screen.getByTestId('report-download-button'));
+
+      await waitFor(() => {
+        expect(loginTrackingService.downloadReport).toHaveBeenCalledWith({
+          mode: 'individual',
+          startDate: '2025-12-01',
+          endDate: '2025-12-31',
+        });
+      });
+    });
+
+    it('should show downloading state while download is in progress', async () => {
+      let resolvePromise: ((value: any) => void) | null = null;
+      vi.mocked(loginTrackingService.downloadReport).mockImplementation(() => 
+        new Promise(resolve => { resolvePromise = resolve; })
+      );
+
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={false} />,
+        {},
+        { user: { id: 1, username: 'testuser', is_staff: false, is_superuser: false } }
+      );
+
+      fireEvent.click(screen.getByTestId('report-download-button'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Downloading...')).toBeInTheDocument();
+        expect(screen.getByTestId('report-download-button')).toBeDisabled();
+      });
+
+      // Clean up by resolving the promise
+      resolvePromise!({
+        blob: new Blob(['test']),
+        filename: 'login_report_testuser_individual_20260101_120000.xlsx',
+      });
+    });
+
+    it('should display error message on download failure', async () => {
+      vi.mocked(loginTrackingService.downloadReport).mockRejectedValue(
+        new Error('Download failed')
+      );
+
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={false} />,
+        {},
+        { user: { id: 1, username: 'testuser', is_staff: false, is_superuser: false } }
+      );
+
+      fireEvent.click(screen.getByTestId('report-download-button'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Failed to download report. Please try again.')).toBeInTheDocument();
+      });
+    });
+
+    it('should not open modal for regular user on click', () => {
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={false} />,
+        {},
+        { user: { id: 1, username: 'testuser', is_staff: false, is_superuser: false } }
+      );
+
+      fireEvent.click(screen.getByTestId('report-download-button'));
+
+      // Modal should not appear for regular user
+      expect(screen.queryByTestId('report-download-modal')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Admin User', () => {
+    it('should open confirmation modal when admin clicks download button', () => {
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={true} />,
+        {},
+        { user: { id: 1, username: 'admin', is_staff: true, is_superuser: false } }
+      );
+
+      fireEvent.click(screen.getByTestId('report-download-button'));
+
+      expect(screen.getByTestId('report-download-modal')).toBeInTheDocument();
+    });
+
+    it('should show readonly mode info from dashboard state in admin modal', () => {
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={true} />,
+        { chartMode: 'individual' },
+        { user: { id: 1, username: 'admin', is_staff: true, is_superuser: false } }
+      );
+
+      fireEvent.click(screen.getByTestId('report-download-button'));
+
+      expect(screen.getByTestId('report-download-modal')).toBeInTheDocument();
+      // Mode label should be displayed as text (not as selectable buttons)
+      const modeText = screen.getByTestId('mode-label-text').textContent;
+      expect(modeText).toContain('Individual');
+    });
+
+    it('should show grouped mode as readonly when dashboard chartMode is grouped', () => {
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={true} />,
+        { chartMode: 'grouped', selectedUserIds: [1, 2, 3] },
+        { user: { id: 1, username: 'admin', is_staff: true, is_superuser: false } }
+      );
+
+      fireEvent.click(screen.getByTestId('report-download-button'));
+
+      expect(screen.getByTestId('report-download-modal')).toBeInTheDocument();
+      const modeText = screen.getByTestId('mode-label-text').textContent;
+      expect(modeText).toContain('Grouped');
+    });
+
+    it('should use chartMode from dashboard state for download mode (individual)', async () => {
+      vi.mocked(loginTrackingService.downloadReport).mockResolvedValue({
+        blob: new Blob(['test']),
+        filename: 'login_report_admin_individual_20260101_120000.xlsx',
+      });
+
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={true} />,
+        { chartMode: 'individual' },
+        { user: { id: 1, username: 'admin', is_staff: true, is_superuser: false } }
+      );
+
+      // Open modal
+      fireEvent.click(screen.getByTestId('report-download-button'));
+
+      // Click download in modal
+      fireEvent.click(screen.getByTestId('modal-download-button'));
+
+      await waitFor(() => {
+        expect(loginTrackingService.downloadReport).toHaveBeenCalledWith({
+          mode: 'individual',
+          filter: 'all',
+          role: 'admin',
+        });
+      });
+    });
+
+    it('should use chartMode from dashboard state for download mode (grouped)', async () => {
+      vi.mocked(loginTrackingService.downloadReport).mockResolvedValue({
+        blob: new Blob(['test']),
+        filename: 'login_report_grouped_users_20260101_120000.xlsx',
+      });
+
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={true} />,
+        {
+          chartMode: 'grouped',
+          selectedUserIds: [1, 2, 3],
+          selectedDashboardUserId: 5,
+          currentDropdownUsers: [
+            { id: 5, username: 'normal_user', email: 'normal@example.com' }
+          ],
+        },
+        { user: { id: 1, username: 'admin', is_staff: true, is_superuser: false } }
+      );
+
+      // Open modal
+      fireEvent.click(screen.getByTestId('report-download-button'));
+
+      // Click download
+      fireEvent.click(screen.getByTestId('modal-download-button'));
+
+      await waitFor(() => {
+        expect(loginTrackingService.downloadReport).toHaveBeenCalledWith({
+          mode: 'grouped',
+          userIds: [5],
+          selectedUserId: 5,
+          startDate: undefined,
+          endDate: undefined,
+          filter: 'all',
+          role: 'admin',
+        });
+      });
+    });
+
+    it('should send all dropdown users with selectedUserId in grouped mode', async () => {
+      vi.mocked(loginTrackingService.downloadReport).mockResolvedValue({
+        blob: new Blob(['test']),
+        filename: 'login_report_grouped_all_users.xlsx',
+      });
+
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={true} />,
+        {
+          chartMode: 'grouped',
+          selectedUserIds: [1, 2, 3, 4],
+          selectedDashboardUserId: 2,
+          currentDropdownUsers: [
+            { id: 1, username: 'admin', email: 'admin@example.com' },
+            { id: 2, username: 'normal', email: 'normal@example.com' },
+            { id: 3, username: 'staff', email: 'staff@example.com' },
+            { id: 4, username: 'guest', email: 'guest@example.com' },
+          ],
+        },
+        { user: { id: 1, username: 'admin', is_staff: true, is_superuser: false } }
+      );
+
+      // Open modal
+      fireEvent.click(screen.getByTestId('report-download-button'));
+
+      // Click download
+      fireEvent.click(screen.getByTestId('modal-download-button'));
+
+      await waitFor(() => {
+        // Should send ALL dropdown users for grouped chart data
+        // Plus selectedUserId so the backend uses the correct "Selected User" label
+        expect(loginTrackingService.downloadReport).toHaveBeenCalledWith({
+          mode: 'grouped',
+          userIds: [1, 2, 3, 4],
+          selectedUserId: 2,
+          startDate: undefined,
+          endDate: undefined,
+          filter: 'all',
+          role: 'admin',
+        });
+      });
+    });
+
+    it('should not include selectedUserId in individual mode', async () => {
+      vi.mocked(loginTrackingService.downloadReport).mockResolvedValue({
+        blob: new Blob(['test']),
+        filename: 'login_report_individual.xlsx',
+      });
+
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={true} />,
+        {
+          chartMode: 'individual',
+          selectedDashboardUserId: 5,
+          currentDropdownUsers: [
+            { id: 5, username: 'normal_user', email: 'normal@example.com' }
+          ],
+        },
+        { user: { id: 1, username: 'admin', is_staff: true, is_superuser: false } }
+      );
+
+      // Open modal
+      fireEvent.click(screen.getByTestId('report-download-button'));
+
+      // Click download
+      fireEvent.click(screen.getByTestId('modal-download-button'));
+
+      await waitFor(() => {
+        // Individual mode should NOT send selectedUserId
+        expect(loginTrackingService.downloadReport).toHaveBeenCalledWith({
+          mode: 'individual',
+          userIds: [5],
+          filter: 'all',
+          role: 'admin',
+        });
+        // Verify selectedUserId is NOT in the call
+        const callArgs = vi.mocked(loginTrackingService.downloadReport).mock.calls[0][0];
+        expect(callArgs).not.toHaveProperty('selectedUserId');
+      });
+    });
+
+    it('should not send selectedUserId in grouped mode when no dropdown user selected', async () => {
+      vi.mocked(loginTrackingService.downloadReport).mockResolvedValue({
+        blob: new Blob(['test']),
+        filename: 'login_report_grouped_no_selection.xlsx',
+      });
+
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={true} />,
+        {
+          chartMode: 'grouped',
+          selectedUserIds: [1, 2, 3],
+          selectedDashboardUserId: null,
+          currentDropdownUsers: [
+            { id: 1, username: 'admin', email: 'admin@example.com' },
+            { id: 2, username: 'normal', email: 'normal@example.com' },
+            { id: 3, username: 'staff', email: 'staff@example.com' },
+          ],
+        },
+        { user: { id: 1, username: 'admin', is_staff: true, is_superuser: false } }
+      );
+
+      // Open modal
+      fireEvent.click(screen.getByTestId('report-download-button'));
+
+      // Click download
+      fireEvent.click(screen.getByTestId('modal-download-button'));
+
+      await waitFor(() => {
+        expect(loginTrackingService.downloadReport).toHaveBeenCalledWith({
+          mode: 'grouped',
+          userIds: [1, 2, 3],
+          startDate: undefined,
+          endDate: undefined,
+          filter: 'all',
+          role: 'admin',
+        });
+        // Verify selectedUserId is NOT in the call
+        const callArgs = vi.mocked(loginTrackingService.downloadReport).mock.calls[0][0];
+        expect(callArgs).not.toHaveProperty('selectedUserId');
+      });
+    });
+
+    it('should close modal when cancel is clicked', () => {
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={true} />,
+        {},
+        { user: { id: 1, username: 'admin', is_staff: true, is_superuser: false } }
+      );
+
+      fireEvent.click(screen.getByTestId('report-download-button'));
+      expect(screen.getByTestId('report-download-modal')).toBeInTheDocument();
+
+      // Click cancel
+      fireEvent.click(screen.getByTestId('modal-cancel-button'));
+
+      expect(screen.queryByTestId('report-download-modal')).not.toBeInTheDocument();
+    });
+
+    it('should include selectedDashboardUserId in individual mode when a dropdown user is selected', async () => {
+      vi.mocked(loginTrackingService.downloadReport).mockResolvedValue({
+        blob: new Blob(['test']),
+        filename: 'login_report_admin_individual_20260101_120000.xlsx',
+      });
+
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={true} />,
+        {
+          chartMode: 'individual',
+          selectedDashboardUserId: 5,
+          currentDropdownUsers: [
+            { id: 5, username: 'normal_user', email: 'normal@example.com' }
+          ],
+        },
+        { user: { id: 1, username: 'admin', is_staff: true, is_superuser: false } }
+      );
+
+      // Open modal
+      fireEvent.click(screen.getByTestId('report-download-button'));
+
+      // Click download
+      fireEvent.click(screen.getByTestId('modal-download-button'));
+
+      await waitFor(() => {
+        expect(loginTrackingService.downloadReport).toHaveBeenCalledWith({
+          mode: 'individual',
+          userIds: [5],
+          filter: 'all',
+          role: 'admin',
+        });
+      });
+    });
+
+    it('should NOT include userIds in individual mode when no dropdown user is selected', async () => {
+      vi.mocked(loginTrackingService.downloadReport).mockResolvedValue({
+        blob: new Blob(['test']),
+        filename: 'login_report_admin_individual_20260101_120000.xlsx',
+      });
+
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={true} />,
+        {
+          chartMode: 'individual',
+          selectedDashboardUserId: null,
+        },
+        { user: { id: 1, username: 'admin', is_staff: true, is_superuser: false } }
+      );
+
+      // Open modal
+      fireEvent.click(screen.getByTestId('report-download-button'));
+
+      // Click download
+      fireEvent.click(screen.getByTestId('modal-download-button'));
+
+      await waitFor(() => {
+        expect(loginTrackingService.downloadReport).toHaveBeenCalledWith({
+          mode: 'individual',
+          filter: 'all',
+          role: 'admin',
+        });
+      });
+    });
+
+    it('should show selected user name in modal summary for individual mode with dropdown', () => {
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={true} />,
+        {
+          chartMode: 'individual',
+          selectedDashboardUserId: 5,
+          currentDropdownUsers: [
+            { id: 5, username: 'normal_user', email: 'normal@example.com' }
+          ],
+        },
+        { user: { id: 1, username: 'admin', is_staff: true, is_superuser: false } }
+      );
+
+      fireEvent.click(screen.getByTestId('report-download-button'));
+
+      // Should show the selected user's name
+      expect(screen.getByText(/normal_user/)).toBeInTheDocument();
+    });
+
+    it('should include date range from dashboard state in admin download', async () => {
+      vi.mocked(loginTrackingService.downloadReport).mockResolvedValue({
+        blob: new Blob(['test']),
+        filename: 'login_report_admin_individual_20260101_120000.xlsx',
+      });
+
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={true} />,
+        { startDate: '2025-06-01', endDate: '2025-06-30' },
+        { user: { id: 1, username: 'admin', is_staff: true, is_superuser: false } }
+      );
+
+      // Open modal
+      fireEvent.click(screen.getByTestId('report-download-button'));
+
+      // Click download
+      fireEvent.click(screen.getByTestId('modal-download-button'));
+
+      await waitFor(() => {
+        expect(loginTrackingService.downloadReport).toHaveBeenCalledWith({
+          mode: 'individual',
+          startDate: '2025-06-01',
+          endDate: '2025-06-30',
+          filter: 'all',
+          role: 'admin',
+        });
+      });
+    });
+
+    it('should not have mode selector buttons in admin modal', () => {
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={true} />,
+        { chartMode: 'individual' },
+        { user: { id: 1, username: 'admin', is_staff: true, is_superuser: false } }
+      );
+
+      fireEvent.click(screen.getByTestId('report-download-button'));
+
+      // Mode selector buttons should NOT exist
+      expect(screen.queryByTestId('mode-individual')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('mode-grouped')).not.toBeInTheDocument();
+    });
+
+    it('should show date range summary in admin modal when dates are set', () => {
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={true} />,
+        { chartMode: 'individual', startDate: '2025-06-01', endDate: '2025-06-30' },
+        { user: { id: 1, username: 'admin', is_staff: true, is_superuser: false } }
+      );
+
+      fireEvent.click(screen.getByTestId('report-download-button'));
+
+      expect(screen.getByText(/2025-06-01/)).toBeInTheDocument();
+      expect(screen.getByText(/2025-06-30/)).toBeInTheDocument();
+    });
+  });
+
+  describe('Filter Parameter Integration', () => {
+    it('should pass filter=admin_only when activeFilter is admin for grouped mode', async () => {
+      vi.mocked(loginTrackingService.downloadReport).mockResolvedValue({
+        blob: new Blob(['test']),
+        filename: 'login_report_admin_filtered.xlsx',
+      });
+
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={true} />,
+        {
+          chartMode: 'grouped',
+          activeFilter: 'admin',
+          selectedUserIds: [1, 2],
+          selectedDashboardUserId: 5,
+          currentDropdownUsers: [
+            { id: 5, username: 'admin_user', email: 'admin@example.com' },
+            { id: 10, username: 'another_admin', email: 'another@example.com' },
+          ],
+        },
+        { user: { id: 1, username: 'admin', is_staff: true, is_superuser: false } }
+      );
+
+      fireEvent.click(screen.getByTestId('report-download-button'));
+      fireEvent.click(screen.getByTestId('modal-download-button'));
+
+      await waitFor(() => {
+        expect(loginTrackingService.downloadReport).toHaveBeenCalledWith(
+          expect.objectContaining({
+            mode: 'grouped',
+            filter: 'admin_only',
+            userIds: [5, 10],
+            selectedUserId: 5,
+            role: 'admin',
+          })
+        );
+      });
+    });
+
+    it('should pass filter=regular_users when activeFilter is regular', async () => {
+      vi.mocked(loginTrackingService.downloadReport).mockResolvedValue({
+        blob: new Blob(['test']),
+        filename: 'login_report_regular_filtered.xlsx',
+      });
+
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={true} />,
+        {
+          chartMode: 'grouped',
+          activeFilter: 'regular',
+          selectedUserIds: [1, 2],
+          selectedDashboardUserId: 5,
+          currentDropdownUsers: [
+            { id: 5, username: 'regular_user', email: 'regular@example.com' },
+            { id: 11, username: 'another_regular', email: 'another@example.com' },
+          ],
+        },
+        { user: { id: 1, username: 'admin', is_staff: true, is_superuser: false } }
+      );
+
+      fireEvent.click(screen.getByTestId('report-download-button'));
+      fireEvent.click(screen.getByTestId('modal-download-button'));
+
+      await waitFor(() => {
+        expect(loginTrackingService.downloadReport).toHaveBeenCalledWith(
+          expect.objectContaining({
+            mode: 'grouped',
+            filter: 'regular_users',
+            userIds: [5, 11],
+            selectedUserId: 5,
+            role: 'admin',
+          })
+        );
+      });
+    });
+
+    it('should pass filter=me when activeFilter is me for individual mode', async () => {
+      vi.mocked(loginTrackingService.downloadReport).mockResolvedValue({
+        blob: new Blob(['test']),
+        filename: 'login_report_me.xlsx',
+      });
+
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={true} />,
+        {
+          chartMode: 'individual',
+          activeFilter: 'me',
+        },
+        { user: { id: 1, username: 'admin', is_staff: true, is_superuser: false } }
+      );
+
+      fireEvent.click(screen.getByTestId('report-download-button'));
+      fireEvent.click(screen.getByTestId('modal-download-button'));
+
+      await waitFor(() => {
+        expect(loginTrackingService.downloadReport).toHaveBeenCalledWith(
+          expect.objectContaining({
+            mode: 'individual',
+            filter: 'me',
+            role: 'admin',
+          })
+        );
+      });
+    });
+
+    it('should pass filter=all when activeFilter is all for grouped mode', async () => {
+      vi.mocked(loginTrackingService.downloadReport).mockResolvedValue({
+        blob: new Blob(['test']),
+        filename: 'login_report_all.xlsx',
+      });
+
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={true} />,
+        {
+          chartMode: 'grouped',
+          activeFilter: 'all',
+          selectedUserIds: [1, 2],
+          selectedDashboardUserId: 3,
+          currentDropdownUsers: [
+            { id: 3, username: 'test_user', email: 'test@example.com' },
+            { id: 7, username: 'another_user', email: 'another@example.com' },
+          ],
+        },
+        { user: { id: 1, username: 'admin', is_staff: true, is_superuser: false } }
+      );
+
+      fireEvent.click(screen.getByTestId('report-download-button'));
+      fireEvent.click(screen.getByTestId('modal-download-button'));
+
+      await waitFor(() => {
+        expect(loginTrackingService.downloadReport).toHaveBeenCalledWith({
+          mode: 'grouped',
+          userIds: [3, 7],
+          selectedUserId: 3,
+          startDate: undefined,
+          endDate: undefined,
+          filter: 'all',
+          role: 'admin',
+        });
+      });
+    });
+
+    it('should not pass filter or role for regular user even with activeFilter me', async () => {
+      vi.mocked(loginTrackingService.downloadReport).mockResolvedValue({
+        blob: new Blob(['test']),
+        filename: 'login_report_regular_user_me.xlsx',
+      });
+
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={false} />,
+        {
+          chartMode: 'individual',
+          activeFilter: 'me',
+        },
+        { user: { id: 1, username: 'regular', is_staff: false, is_superuser: false } }
+      );
+
+      fireEvent.click(screen.getByTestId('report-download-button'));
+
+      await waitFor(() => {
+        expect(loginTrackingService.downloadReport).toHaveBeenCalledWith({
+          mode: 'individual',
+        });
+      });
+    });
+
+    // NEW TESTS: Individual mode with all filter variations
+    it('should pass filter=admin_only for individual mode when activeFilter is admin', async () => {
+      vi.mocked(loginTrackingService.downloadReport).mockResolvedValue({
+        blob: new Blob(['test']),
+        filename: 'login_report_admin_individual_filtered.xlsx',
+      });
+
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={true} />,
+        {
+          chartMode: 'individual',
+          activeFilter: 'admin',
+        },
+        { user: { id: 1, username: 'admin', is_staff: true, is_superuser: false } }
+      );
+
+      fireEvent.click(screen.getByTestId('report-download-button'));
+      fireEvent.click(screen.getByTestId('modal-download-button'));
+
+      await waitFor(() => {
+        expect(loginTrackingService.downloadReport).toHaveBeenCalledWith(
+          expect.objectContaining({
+            mode: 'individual',
+            filter: 'admin_only',
+            role: 'admin',
+          })
+        );
+      });
+    });
+
+    it('should pass filter=regular_users for individual mode when activeFilter is regular', async () => {
+      vi.mocked(loginTrackingService.downloadReport).mockResolvedValue({
+        blob: new Blob(['test']),
+        filename: 'login_report_regular_individual_filtered.xlsx',
+      });
+
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={true} />,
+        {
+          chartMode: 'individual',
+          activeFilter: 'regular',
+        },
+        { user: { id: 1, username: 'admin', is_staff: true, is_superuser: false } }
+      );
+
+      fireEvent.click(screen.getByTestId('report-download-button'));
+      fireEvent.click(screen.getByTestId('modal-download-button'));
+
+      await waitFor(() => {
+        expect(loginTrackingService.downloadReport).toHaveBeenCalledWith(
+          expect.objectContaining({
+            mode: 'individual',
+            filter: 'regular_users',
+            role: 'admin',
+          })
+        );
+      });
+    });
+
+    it('should pass filter=all for individual mode when activeFilter is all', async () => {
+      vi.mocked(loginTrackingService.downloadReport).mockResolvedValue({
+        blob: new Blob(['test']),
+        filename: 'login_report_all_individual_filtered.xlsx',
+      });
+
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={true} />,
+        {
+          chartMode: 'individual',
+          activeFilter: 'all',
+        },
+        { user: { id: 1, username: 'admin', is_staff: true, is_superuser: false } }
+      );
+
+      fireEvent.click(screen.getByTestId('report-download-button'));
+      fireEvent.click(screen.getByTestId('modal-download-button'));
+
+      await waitFor(() => {
+        expect(loginTrackingService.downloadReport).toHaveBeenCalledWith(
+          expect.objectContaining({
+            mode: 'individual',
+            filter: 'all',
+            role: 'admin',
+          })
+        );
+      });
+    });
+
+    it('should not pass filter or role for individual mode with regular user', async () => {
+      vi.mocked(loginTrackingService.downloadReport).mockResolvedValue({
+        blob: new Blob(['test']),
+        filename: 'login_report_me_regular_user.xlsx',
+      });
+
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={false} />,
+        {
+          chartMode: 'individual',
+          activeFilter: 'me',
+        },
+        { user: { id: 1, username: 'regular', is_staff: false, is_superuser: false } }
+      );
+
+      fireEvent.click(screen.getByTestId('report-download-button'));
+
+      await waitFor(() => {
+        expect(loginTrackingService.downloadReport).toHaveBeenCalledWith({
+          mode: 'individual',
+        });
+      });
+    });
+
+    it('should pass filter, role, date, and userIds together for individual mode', async () => {
+      vi.mocked(loginTrackingService.downloadReport).mockResolvedValue({
+        blob: new Blob(['test']),
+        filename: 'login_report_individual_combined.xlsx',
+      });
+
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={true} />,
+        {
+          chartMode: 'individual',
+          activeFilter: 'regular',
+          startDate: '2025-06-01',
+          endDate: '2025-06-30',
+          selectedDashboardUserId: 5,
+          currentDropdownUsers: [
+            { id: 5, username: 'normal_user', email: 'normal@example.com' }
+          ],
+        },
+        { user: { id: 1, username: 'admin', is_staff: true, is_superuser: false } }
+      );
+
+      fireEvent.click(screen.getByTestId('report-download-button'));
+      fireEvent.click(screen.getByTestId('modal-download-button'));
+
+      await waitFor(() => {
+        expect(loginTrackingService.downloadReport).toHaveBeenCalledWith(
+          expect.objectContaining({
+            mode: 'individual',
+            filter: 'regular_users',
+            role: 'admin',
+            userIds: [5],
+            startDate: '2025-06-01',
+            endDate: '2025-06-30',
+          })
+        );
+      });
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should clear error after new successful download', async () => {
+      // First make it fail
+      vi.mocked(loginTrackingService.downloadReport)
+        .mockRejectedValueOnce(new Error('First fail'))
+        .mockResolvedValueOnce({
+          blob: new Blob(['test']),
+          filename: 'login_report_testuser_individual_20260101_120000.xlsx',
+        });
+
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={false} />,
+        {},
+        { user: { id: 1, username: 'testuser', is_staff: false, is_superuser: false } }
+      );
+
+      // First click - should fail
+      fireEvent.click(screen.getByTestId('report-download-button'));
+      await waitFor(() => {
+        expect(screen.getByText('Failed to download report. Please try again.')).toBeInTheDocument();
+      });
+
+      // Second click - should succeed and clear error
+      fireEvent.click(screen.getByTestId('report-download-button'));
+      await waitFor(() => {
+        expect(screen.queryByText('Failed to download report. Please try again.')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Dark Mode', () => {
+    beforeEach(() => {
+      // Enable dark mode
+      document.documentElement.classList.add('dark');
+    });
+
+    it('should render button with dark mode styles when dark class is present', () => {
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={false} />,
+        {},
+        { user: { id: 1, username: 'testuser', is_staff: false, is_superuser: false } }
+      );
+
+      const button = screen.getByTestId('report-download-button');
+      expect(button).toBeInTheDocument();
+      // Button should be rendered (dark mode class applied via twin.macro)
+      // The dark class is on document, twin.macro will apply dark:bg-blue-600
+      expect(document.documentElement.classList.contains('dark')).toBe(true);
+    });
+
+    it('should render admin modal with dark mode card styles when dark class is present', () => {
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={true} />,
+        {},
+        { user: { id: 1, username: 'admin', is_staff: true, is_superuser: false } }
+      );
+
+      fireEvent.click(screen.getByTestId('report-download-button'));
+
+      const modal = screen.getByTestId('report-download-modal');
+      expect(modal).toBeInTheDocument();
+      expect(document.documentElement.classList.contains('dark')).toBe(true);
+    });
+
+    it('should render error message with dark mode error styles when dark class is present', async () => {
+      vi.mocked(loginTrackingService.downloadReport).mockRejectedValue(
+        new Error('Download failed')
+      );
+
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={false} />,
+        {},
+        { user: { id: 1, username: 'testuser', is_staff: false, is_superuser: false } }
+      );
+
+      fireEvent.click(screen.getByTestId('report-download-button'));
+
+      await waitFor(() => {
+        const errorMessage = screen.getByTestId('download-error-message');
+        expect(errorMessage).toBeInTheDocument();
+        expect(errorMessage.textContent).toContain('Failed to download report. Please try again.');
+      });
+      expect(document.documentElement.classList.contains('dark')).toBe(true);
+    });
+
+    it('should render modal summary section with dark mode background when dark class is present', () => {
+      renderWithProviders(
+        <ReportDownloadButton isAdmin={true} />,
+        { chartMode: 'grouped', selectedUserIds: [1, 2, 3] },
+        { user: { id: 1, username: 'admin', is_staff: true, is_superuser: false } }
+      );
+
+      fireEvent.click(screen.getByTestId('report-download-button'));
+
+      const modal = screen.getByTestId('report-download-modal');
+      expect(modal).toBeInTheDocument();
+      const modeText = screen.getByTestId('mode-label-text');
+      expect(modeText).toBeInTheDocument();
+      expect(modeText.textContent).toContain('Grouped');
+      expect(document.documentElement.classList.contains('dark')).toBe(true);
+    });
+  });
+});

--- a/src/components/dashboard/ReportDownloadButton.tsx
+++ b/src/components/dashboard/ReportDownloadButton.tsx
@@ -1,0 +1,334 @@
+import React, { useState, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
+import tw from 'twin.macro';
+import { RootState } from '../../store';
+import { downloadReport, DownloadReportResult } from '../../services/loginTrackingService';
+
+interface ReportDownloadButtonProps {
+  isAdmin: boolean;
+}
+
+// Styled components with dark mode support
+const DownloadButton = tw.button`
+  inline-flex items-center gap-2 px-5 py-2.5 text-sm font-semibold text-white
+  bg-blue-500 hover:bg-blue-600
+  dark:bg-blue-600 dark:hover:bg-blue-700
+  rounded-lg border-none cursor-pointer
+  transition-colors duration-200
+  disabled:bg-gray-400 disabled:cursor-not-allowed
+  dark:disabled:bg-gray-600
+`;
+
+const ErrorBox = tw.div`
+  mt-2 px-3 py-2 text-sm rounded-lg
+  bg-red-50 border border-red-200 text-red-700
+  dark:bg-red-900/20 dark:border-red-700 dark:text-red-300
+`;
+
+const ModalOverlay = tw.div`
+  fixed inset-0 bg-black/50 backdrop-blur-sm
+  flex items-center justify-center z-50
+`;
+
+const ModalCard = tw.div`
+  bg-white dark:bg-dark-secondary
+  rounded-xl p-6 max-w-md w-11/12
+  shadow-lg border border-gray-100 dark:border-dark-accent
+`;
+
+const ModalTitle = tw.h3`
+  m-0 text-lg font-bold text-gray-900 dark:text-dark-text
+  mb-1
+`;
+
+const ModalSubtitle = tw.p`
+  m-0 mb-5 text-sm text-gray-500 dark:text-gray-400
+`;
+
+const SummaryBox = tw.div`
+  bg-gray-50 dark:bg-dark-accent
+  rounded-lg p-4 mb-5
+  border border-gray-200 dark:border-dark-accent
+`;
+
+const SummaryLabel = tw.div`
+  text-xs font-medium text-gray-500 dark:text-gray-400 mb-2
+`;
+
+const SummaryContent = tw.div`
+  text-xs text-gray-600 dark:text-gray-400 leading-relaxed
+`;
+
+const SummaryItem = tw.div``;
+
+const ModalActions = tw.div`
+  flex gap-3 justify-end
+`;
+
+const CancelButton = tw.button`
+  px-5 py-2.5 text-sm font-medium rounded-lg
+  bg-gray-100 text-gray-700 border border-gray-200
+  dark:bg-dark-accent dark:text-gray-300 dark:border-dark-accent
+  cursor-pointer hover:bg-gray-200 dark:hover:bg-dark-secondary
+  disabled:cursor-not-allowed disabled:opacity-50
+  transition-colors duration-200
+`;
+
+const DownloadActionButton = tw.button`
+  inline-flex items-center gap-1.5 px-5 py-2.5 text-sm font-semibold text-white
+  bg-green-500 hover:bg-green-600
+  dark:bg-green-600 dark:hover:bg-green-700
+  rounded-lg border-none cursor-pointer
+  disabled:bg-gray-400 disabled:cursor-not-allowed
+  dark:disabled:bg-gray-600
+  transition-colors duration-200
+`;
+
+const DownloadIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+    <polyline points="7 10 12 15 17 10" />
+    <line x1="12" y1="15" x2="12" y2="3" />
+  </svg>
+);
+
+/**
+ * ReportDownloadButton Component
+ * 
+ * For regular users: Downloads report directly in individual mode (no modal)
+ * For admin users: Shows a confirmation modal with readonly mode info from dashboard state
+ * 
+ * The download mode (individual/grouped) is driven by dashboardState.chartMode
+ * which is set by the ChartModeToggle component in the dashboard.
+ * 
+ * When an admin selects a dropdown user (selectedDashboardUserId) in individual mode,
+ * the user_ids[] parameter is sent to the backend so the report shows that user's data.
+ * 
+ * Supports dark/light theme via twin.macro dark: variants.
+ */
+const ReportDownloadButton: React.FC<ReportDownloadButtonProps> = ({ isAdmin }) => {
+  const { t } = useTranslation();
+  const dashboardState = useSelector((state: RootState) => state.dashboard);
+  
+  const [downloading, setDownloading] = useState(false);
+  const [downloadError, setDownloadError] = useState<string | null>(null);
+  const [showModal, setShowModal] = useState(false);
+
+  /**
+   * Trigger the file download in the browser
+   */
+  const triggerDownload = useCallback((result: DownloadReportResult) => {
+    const url = window.URL.createObjectURL(new Blob([result.blob]));
+    const link = document.createElement('a');
+    link.href = url;
+    link.setAttribute('download', result.filename);
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    window.URL.revokeObjectURL(url);
+  }, []);
+
+  /**
+   * Find the selected dropdown user's name from currentDropdownUsers
+   */
+  const getSelectedUserLabel = useCallback((): string | null => {
+    const { selectedDashboardUserId, currentDropdownUsers } = dashboardState;
+    if (!selectedDashboardUserId || !currentDropdownUsers.length) return null;
+    const user = currentDropdownUsers.find(u => u.id === selectedDashboardUserId);
+    return user ? user.username : null;
+  }, [dashboardState]);
+
+  const authState = useSelector((state: RootState) => state.auth);
+
+  /**
+   * Map activeFilter from dashboard state to backend filter parameter
+   */
+  const getFilterParam = useCallback((): 'all' | 'admin_only' | 'regular_users' | 'me' | undefined => {
+    switch (dashboardState.activeFilter) {
+      case 'admin':
+        return 'admin_only';
+      case 'regular':
+        return 'regular_users';
+      case 'me':
+        return 'me';
+      case 'all':
+        return 'all';
+      default:
+        return undefined;
+    }
+  }, [dashboardState.activeFilter]);
+
+  /**
+   * Get role parameter from auth user's actual role
+   */
+  const getRoleParam = useCallback((): 'admin' | 'regular' | undefined => {
+    const user = authState.user;
+    if (!user) return undefined;
+    if (user.is_staff || user.is_superuser) {
+      return 'admin';
+    }
+    return 'regular';
+  }, [authState.user]);
+
+  /**
+   * Execute the download using mode from dashboard state
+   */
+  const handleDownload = useCallback(async () => {
+    setDownloading(true);
+    setDownloadError(null);
+
+    const mode = dashboardState.chartMode;
+
+    // Build userIds and selectedUserId for the API call:
+    // - Individual mode: send only the dropdown-selected user (no selectedUserId needed)
+    // - Grouped mode: send all dropdown users for grouped chart data, plus selectedUserId
+    //   so the backend knows which user to label as "Selected User"
+    let userIds: number[] | undefined;
+    let selectedUserId: number | undefined;
+
+    if (mode === 'individual' && dashboardState.selectedDashboardUserId !== null) {
+      userIds = [dashboardState.selectedDashboardUserId];
+    } else if (mode === 'grouped') {
+      const allDropdownUserIds = dashboardState.currentDropdownUsers.map(u => u.id);
+      if (allDropdownUserIds.length > 0) {
+        userIds = allDropdownUserIds;
+        if (dashboardState.selectedDashboardUserId !== null) {
+          selectedUserId = dashboardState.selectedDashboardUserId;
+        }
+      }
+    }
+
+    try {
+      const params: Parameters<typeof downloadReport>[0] = {
+        mode,
+        userIds,
+        startDate: dashboardState.startDate || undefined,
+        endDate: dashboardState.endDate || undefined,
+        ...(isAdmin && { filter: getFilterParam(), role: getRoleParam() }),
+      };
+      // Only include selectedUserId when defined (not needed for individual mode)
+      if (selectedUserId !== undefined) {
+        params.selectedUserId = selectedUserId;
+      }
+      const result = await downloadReport(params);
+      
+      triggerDownload(result);
+      setShowModal(false);
+    } catch (_error) {
+      const errorMessage = t('dashboard.report_download.file_error');
+      setDownloadError(errorMessage);
+    } finally {
+      setDownloading(false);
+    }
+  }, [dashboardState, t, triggerDownload, getFilterParam, getRoleParam, isAdmin]);
+
+  /**
+   * Handle button click based on user role
+   */
+  const onButtonClick = useCallback(() => {
+    if (isAdmin) {
+      setShowModal(true);
+    } else {
+      handleDownload();
+    }
+  }, [isAdmin, handleDownload]);
+
+  /**
+   * Close the modal
+   */
+  const closeModal = useCallback(() => {
+    setShowModal(false);
+  }, []);
+
+  const mode = dashboardState.chartMode;
+  const selectedUserLabel = getSelectedUserLabel();
+
+  return (
+    <div>
+      {/* Download Button */}
+      <DownloadButton
+        data-testid="report-download-button"
+        onClick={onButtonClick}
+        disabled={downloading}
+      >
+        <DownloadIcon />
+        {downloading ? t('dashboard.report_download.downloading') : t('dashboard.report_download.button')}
+      </DownloadButton>
+
+      {/* Error Message */}
+      {downloadError && (
+        <ErrorBox data-testid="download-error-message">
+          {downloadError}
+        </ErrorBox>
+      )}
+
+      {/* Admin Modal */}
+      {showModal && (
+        <ModalOverlay
+          data-testid="report-download-modal"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) closeModal();
+          }}
+        >
+          <ModalCard>
+            {/* Modal Header */}
+            <ModalTitle>
+              {t('dashboard.report_download.confirm_title')}
+            </ModalTitle>
+            <ModalSubtitle>
+              {t('dashboard.report_download.confirm_summary')}
+            </ModalSubtitle>
+
+            {/* Readonly Summary Info */}
+            <SummaryBox>
+              <SummaryLabel>
+                {t('dashboard.report_download.confirm_summary')}
+              </SummaryLabel>
+              <SummaryContent>
+                <SummaryItem data-testid="mode-label-text">
+                  • <span>{t('dashboard.report_download.mode_label')}</span>: {mode === 'individual' ? t('dashboard.report_download.individual') : t('dashboard.report_download.grouped')}
+                </SummaryItem>
+                {dashboardState.startDate && dashboardState.endDate && (
+                  <SummaryItem>
+                    • {t('dashboard.dateRange.title')}: {dashboardState.startDate} ~ {dashboardState.endDate}
+                  </SummaryItem>
+                )}
+                {mode === 'grouped' && dashboardState.selectedUserIds.length > 0 && (
+                  <SummaryItem>
+                    • {t('dashboard.user_selector.label')}: {dashboardState.selectedUserIds.length} users
+                  </SummaryItem>
+                )}
+                {mode === 'individual' && selectedUserLabel && (
+                  <SummaryItem>
+                    • {t('dashboard.user_selector.selected')}: {selectedUserLabel}
+                  </SummaryItem>
+                )}
+              </SummaryContent>
+            </SummaryBox>
+
+            {/* Action Buttons */}
+            <ModalActions>
+              <CancelButton
+                data-testid="modal-cancel-button"
+                onClick={closeModal}
+                disabled={downloading}
+              >
+                {t('dashboard.report_download.cancel')}
+              </CancelButton>
+              <DownloadActionButton
+                data-testid="modal-download-button"
+                onClick={handleDownload}
+                disabled={downloading}
+              >
+                {downloading ? t('dashboard.report_download.downloading') : t('dashboard.report_download.download')}
+              </DownloadActionButton>
+            </ModalActions>
+          </ModalCard>
+        </ModalOverlay>
+      )}
+    </div>
+  );
+};
+
+export default ReportDownloadButton;

--- a/src/components/dashboard/__tests__/ReportDownloadButton.i18n.test.tsx
+++ b/src/components/dashboard/__tests__/ReportDownloadButton.i18n.test.tsx
@@ -1,0 +1,78 @@
+import i18n from '../../../locale/i18n';
+import { describe, beforeEach, it, expect } from 'vitest';
+
+describe('ReportDownloadButton i18n Integration', () => {
+  beforeEach(() => {
+    i18n.changeLanguage('en');
+  });
+
+  it.each([
+    {
+      lang: 'en',
+      expectedButton: 'Download Report',
+      expectedDownloading: 'Downloading...',
+      expectedConfirmTitle: 'Download Report',
+      expectedConfirmSummary: 'Report Summary',
+      expectedMode: 'Mode',
+      expectedIndividual: 'Individual',
+      expectedGrouped: 'Grouped',
+      expectedCancel: 'Cancel',
+      expectedDownload: 'Download Excel',
+      expectedFileError: 'Failed to download report. Please try again.',
+    },
+    {
+      lang: 'ml',
+      expectedButton: 'റിപ്പോർട്ട് ഡൗൺലോഡ്',
+      expectedDownloading: 'ഡൗൺലോഡ് ചെയ്യുന്നു...',
+      expectedConfirmTitle: 'റിപ്പോർട്ട് ഡൗൺലോഡ്',
+      expectedConfirmSummary: 'റിപ്പോർട്ട് സംഗ്രഹം',
+      expectedMode: 'മോഡ്',
+      expectedIndividual: 'വ്യക്തിഗതം',
+      expectedGrouped: 'ഗ്രൂപ്പ്',
+      expectedCancel: 'റദ്ദാക്കുക',
+      expectedDownload: 'Excel ഡൗൺലോഡ്',
+      expectedFileError: 'റിപ്പോർട്ട് ഡൗൺലോഡ് ചെയ്യുന്നതിൽ പരാജയപ്പെട്ടു. ദയവായി വീണ്ടും ശ്രമിക്കുക.',
+    },
+    {
+      lang: 'ar',
+      expectedButton: 'تحميل التقرير',
+      expectedDownloading: 'جاري التحميل...',
+      expectedConfirmTitle: 'تحميل التقرير',
+      expectedConfirmSummary: 'ملخص التقرير',
+      expectedMode: 'الوضع',
+      expectedIndividual: 'فردي',
+      expectedGrouped: 'مجموعة',
+      expectedCancel: 'إلغاء',
+      expectedDownload: 'تحميل Excel',
+      expectedFileError: 'فشل تحميل التقرير. يرجى المحاولة مرة أخرى.',
+    },
+  ])(
+    'displays report download translations correctly in $lang',
+    async ({
+      lang,
+      expectedButton,
+      expectedDownloading,
+      expectedConfirmTitle,
+      expectedConfirmSummary,
+      expectedMode,
+      expectedIndividual,
+      expectedGrouped,
+      expectedCancel,
+      expectedDownload,
+      expectedFileError,
+    }) => {
+      await i18n.changeLanguage(lang);
+
+      expect(i18n.t('dashboard.report_download.button')).toBe(expectedButton);
+      expect(i18n.t('dashboard.report_download.downloading')).toBe(expectedDownloading);
+      expect(i18n.t('dashboard.report_download.confirm_title')).toBe(expectedConfirmTitle);
+      expect(i18n.t('dashboard.report_download.confirm_summary')).toBe(expectedConfirmSummary);
+      expect(i18n.t('dashboard.report_download.mode_label')).toBe(expectedMode);
+      expect(i18n.t('dashboard.report_download.individual')).toBe(expectedIndividual);
+      expect(i18n.t('dashboard.report_download.grouped')).toBe(expectedGrouped);
+      expect(i18n.t('dashboard.report_download.cancel')).toBe(expectedCancel);
+      expect(i18n.t('dashboard.report_download.download')).toBe(expectedDownload);
+      expect(i18n.t('dashboard.report_download.file_error')).toBe(expectedFileError);
+    }
+  );
+});

--- a/src/locale/i18n.ts
+++ b/src/locale/i18n.ts
@@ -220,6 +220,7 @@ i18n.use(initReactI18next).init({
           },
           user_selector: {
             label: "Select User",
+            selected: "Selected User",
             aria_label: "Select user for dashboard",
             error_loading: "Error loading users",
             no_users: "No users available"
@@ -239,6 +240,18 @@ i18n.use(initReactI18next).init({
             showingLast7Days: "Showing data for the last 7 days",
             showingLast1Day: "Showing data for the last 1 day",
             showingCustomRange: "Showing data for custom date range"
+          },
+          report_download: {
+            button: "Download Report",
+            downloading: "Downloading...",
+            confirm_title: "Download Report",
+            confirm_summary: "Report Summary",
+            mode_label: "Mode",
+            individual: "Individual",
+            grouped: "Grouped",
+            cancel: "Cancel",
+            download: "Download Excel",
+            file_error: "Failed to download report. Please try again.",
           },
           user_not_found: "User not found",
           unauthorized_access: "Unauthorized access to dashboard data"
@@ -543,6 +556,7 @@ i18n.use(initReactI18next).init({
           },
           user_selector: {
             label: "ഉപയോക്താവിനെ തിരഞ്ഞെടുക്കുക",
+            selected: "തിരഞ്ഞെടുത്ത ഉപയോക്താവ്",
             aria_label: "ഡാഷ്ബോർഡിനായി ഉപയോക്താവിനെ തിരഞ്ഞെടുക്കുക",
             error_loading: "ഉപയോക്താക്കളെ ലോഡ് ചെയ്യുന്നതിൽ പിശക്",
             no_users: "ഉപയോക്താക്കളെ ലഭ്യമല്ല"
@@ -551,6 +565,18 @@ i18n.use(initReactI18next).init({
             label: "ചാർട്ട് മോഡ്",
             individual: "വ്യക്തിഗതം",
             group: "ഗ്രൂപ്പ്"
+          },
+          report_download: {
+            button: "റിപ്പോർട്ട് ഡൗൺലോഡ്",
+            downloading: "ഡൗൺലോഡ് ചെയ്യുന്നു...",
+            confirm_title: "റിപ്പോർട്ട് ഡൗൺലോഡ്",
+            confirm_summary: "റിപ്പോർട്ട് സംഗ്രഹം",
+            mode_label: "മോഡ്",
+            individual: "വ്യക്തിഗതം",
+            grouped: "ഗ്രൂപ്പ്",
+            cancel: "റദ്ദാക്കുക",
+            download: "Excel ഡൗൺലോഡ്",
+            file_error: "റിപ്പോർട്ട് ഡൗൺലോഡ് ചെയ്യുന്നതിൽ പരാജയപ്പെട്ടു. ദയവായി വീണ്ടും ശ്രമിക്കുക.",
           },
           user_not_found: "ഉപയോക്താവിനെ കണ്ടെത്തിയില്ല",
           unauthorized_access: "ഡാഷ്ബോർഡ് ഡാറ്റയിലേക്ക് അനധികൃത ആക്സസ്"
@@ -854,6 +880,7 @@ i18n.use(initReactI18next).init({
           },
           user_selector: {
             label: "اختر المستخدم",
+            selected: "المستخدم المحدد",
             aria_label: "اختر مستخدم للوحة التحكم",
             error_loading: "خطأ في تحميل المستخدمين",
             no_users: "لا يوجد مستخدمون متاحون"
@@ -862,6 +889,18 @@ i18n.use(initReactI18next).init({
             label: "وضع الرسم البياني",
             individual: "فردي",
             group: "مجموعة"
+          },
+          report_download: {
+            button: "تحميل التقرير",
+            downloading: "جاري التحميل...",
+            confirm_title: "تحميل التقرير",
+            confirm_summary: "ملخص التقرير",
+            mode_label: "الوضع",
+            individual: "فردي",
+            grouped: "مجموعة",
+            cancel: "إلغاء",
+            download: "تحميل Excel",
+            file_error: "فشل تحميل التقرير. يرجى المحاولة مرة أخرى.",
           },
           user_not_found: "لم يتم العثور على المستخدم",
           unauthorized_access: "وصول غير مصرح به لبيانات لوحة التحكم"

--- a/src/services/__tests__/loginTrackingService.test.ts
+++ b/src/services/__tests__/loginTrackingService.test.ts
@@ -916,7 +916,430 @@ describe('loginTrackingService', () => {
     });
   });
 
-  // Test authentication error handling - removed due to complex mocking issues
-  // The authentication is already handled by the buildHeaders function which
-  // is properly tested through the error handling in individual service calls
+  // Test downloadReport function
+  describe('downloadReport', () => {
+    it('should download report and return blob with filename for individual mode', async () => {
+      (globalThis.fetch as any).mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(['mock xlsx content'])),
+        headers: new Map([
+          ['content-disposition', 'attachment; filename="login_report_testuser_individual_20260101_120000.xlsx"'],
+          ['content-type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+        ]),
+      });
+
+      const result = await getDownloadReport({ mode: 'individual' });
+      expect(result).toBeDefined();
+      expect(result.filename).toBe('login_report_testuser_individual_20260101_120000.xlsx');
+      expect(result.blob).toBeDefined();
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/user/dashboard/report/download/?mode=individual'),
+        expect.any(Object)
+      );
+    });
+
+    it('should include date parameters when provided', async () => {
+      (globalThis.fetch as any).mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(['mock xlsx content'])),
+        headers: new Map([
+          ['content-disposition', 'attachment; filename="login_report_testuser_individual_20260101_120000.xlsx"'],
+          ['content-type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+        ]),
+      });
+
+      const result = await getDownloadReport({
+        mode: 'individual',
+        startDate: '2025-12-01',
+        endDate: '2025-12-31',
+      });
+      expect(result).toBeDefined();
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/user/dashboard/report/download/?mode=individual&start_date=2025-12-01&end_date=2025-12-31'),
+        expect.any(Object)
+      );
+    });
+
+    it('should include user_ids parameter when provided', async () => {
+      (globalThis.fetch as any).mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(['mock xlsx content'])),
+        headers: new Map([
+          ['content-disposition', 'attachment; filename="login_report_admin_individual_20260101_120000.xlsx"'],
+          ['content-type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+        ]),
+      });
+
+      const result = await getDownloadReport({
+        mode: 'individual',
+        userIds: [1, 2, 3],
+      });
+      expect(result).toBeDefined();
+      const fetchCall = (globalThis.fetch as any).mock.calls[0][0];
+      expect(fetchCall).toContain('/api/user/dashboard/report/download/');
+      expect(fetchCall).toContain('mode=individual');
+      expect(fetchCall).toContain('user_ids%5B%5D=1');
+      expect(fetchCall).toContain('user_ids%5B%5D=2');
+      expect(fetchCall).toContain('user_ids%5B%5D=3');
+    });
+
+    it('should handle grouped mode download', async () => {
+      (globalThis.fetch as any).mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(['mock xlsx content'])),
+        headers: new Map([
+          ['content-disposition', 'attachment; filename="login_report_grouped_3_users_20260101_120000.xlsx"'],
+          ['content-type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+        ]),
+      });
+
+      const result = await getDownloadReport({
+        mode: 'grouped',
+        userIds: [1, 2, 3],
+      });
+      expect(result).toBeDefined();
+      expect(result.filename).toContain('login_report_grouped');
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/user/dashboard/report/download/?mode=grouped'),
+        expect.any(Object)
+      );
+    });
+
+    it('should throw error on 400 response', async () => {
+      (globalThis.fetch as any).mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: () => Promise.resolve({ error: "Missing required parameter: 'mode'." }),
+        headers: new Map(),
+      });
+
+      await expect(getDownloadReport({ mode: 'individual' })).rejects.toBeDefined();
+    });
+
+    it('should throw error on 403 response', async () => {
+      (globalThis.fetch as any).mockResolvedValue({
+        ok: false,
+        status: 403,
+        json: () => Promise.resolve({ error: "Only admin users can use grouped mode." }),
+        headers: new Map(),
+      });
+
+      await expect(getDownloadReport({ mode: 'grouped' })).rejects.toBeDefined();
+    });
+
+    it('should throw error on 401 response', async () => {
+      (globalThis.fetch as any).mockResolvedValue({
+        ok: false,
+        status: 401,
+        json: () => Promise.resolve({ detail: 'Token is invalid or expired' }),
+        headers: new Map(),
+      });
+
+      await expect(getDownloadReport({ mode: 'individual' })).rejects.toBeDefined();
+    });
+
+    it('should extract filename from Content-Disposition header', async () => {
+      (globalThis.fetch as any).mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(['mock xlsx content'])),
+        headers: new Map([
+          ['content-disposition', 'attachment; filename="login_report_johndoe_individual_20260101_120000.xlsx"'],
+          ['content-type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+        ]),
+      });
+
+      const result = await getDownloadReport({ mode: 'individual' });
+      expect(result.filename).toBe('login_report_johndoe_individual_20260101_120000.xlsx');
+    });
+
+    it('should fallback to default filename when Content-Disposition is missing', async () => {
+      (globalThis.fetch as any).mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(['mock xlsx content'])),
+        headers: new Map([
+          ['content-type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+        ]),
+      });
+
+      // Mock the getDownloadReport to handle missing Content-Disposition
+      const result = await getDownloadReport({ mode: 'individual' });
+      // Should have a fallback filename
+      expect(result.filename).toBe('login_report.xlsx');
+    });
+
+    it('should include filter=admin_only when filter param is provided for grouped mode', async () => {
+      (globalThis.fetch as any).mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(['mock xlsx content'])),
+        headers: new Map([
+          ['content-disposition', 'attachment; filename="login_report_admin_20260101_120000.xlsx"'],
+          ['content-type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+        ]),
+      });
+
+      const result = await getDownloadReport({ mode: 'grouped', filter: 'admin_only' });
+      expect(result).toBeDefined();
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/user/dashboard/report/download/?mode=grouped&filter=admin_only'),
+        expect.any(Object)
+      );
+    });
+
+    it('should include filter=regular_users when filter param is provided for grouped mode', async () => {
+      (globalThis.fetch as any).mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(['mock xlsx content'])),
+        headers: new Map([
+          ['content-disposition', 'attachment; filename="login_report_regular_20260101_120000.xlsx"'],
+          ['content-type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+        ]),
+      });
+
+      const result = await getDownloadReport({ mode: 'grouped', filter: 'regular_users' });
+      expect(result).toBeDefined();
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/user/dashboard/report/download/?mode=grouped&filter=regular_users'),
+        expect.any(Object)
+      );
+    });
+
+    it('should include filter=me when filter param is provided for grouped mode', async () => {
+      (globalThis.fetch as any).mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(['mock xlsx content'])),
+        headers: new Map([
+          ['content-disposition', 'attachment; filename="login_report_me_20260101_120000.xlsx"'],
+          ['content-type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+        ]),
+      });
+
+      const result = await getDownloadReport({ mode: 'grouped', filter: 'me' });
+      expect(result).toBeDefined();
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/user/dashboard/report/download/?mode=grouped&filter=me'),
+        expect.any(Object)
+      );
+    });
+
+    it('should include filter=all when filter param is provided for grouped mode', async () => {
+      (globalThis.fetch as any).mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(['mock xlsx content'])),
+        headers: new Map([
+          ['content-disposition', 'attachment; filename="login_report_all_20260101_120000.xlsx"'],
+          ['content-type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+        ]),
+      });
+
+      const result = await getDownloadReport({ mode: 'grouped', filter: 'all' });
+      expect(result).toBeDefined();
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/user/dashboard/report/download/?mode=grouped&filter=all'),
+        expect.any(Object)
+      );
+    });
+
+    it('should include role=admin when role param is provided for grouped mode', async () => {
+      (globalThis.fetch as any).mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(['mock xlsx content'])),
+        headers: new Map([
+          ['content-disposition', 'attachment; filename="login_report_admin_role_20260101_120000.xlsx"'],
+          ['content-type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+        ]),
+      });
+
+      const result = await getDownloadReport({ mode: 'grouped', role: 'admin' });
+      expect(result).toBeDefined();
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/user/dashboard/report/download/?mode=grouped&role=admin'),
+        expect.any(Object)
+      );
+    });
+
+    it('should include role=regular when role param is provided for grouped mode', async () => {
+      (globalThis.fetch as any).mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(['mock xlsx content'])),
+        headers: new Map([
+          ['content-disposition', 'attachment; filename="login_report_regular_role_20260101_120000.xlsx"'],
+          ['content-type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+        ]),
+      });
+
+      const result = await getDownloadReport({ mode: 'grouped', role: 'regular' });
+      expect(result).toBeDefined();
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/user/dashboard/report/download/?mode=grouped&role=regular'),
+        expect.any(Object)
+      );
+    });
+
+    it('should include both filter and date params together for grouped mode', async () => {
+      (globalThis.fetch as any).mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(['mock xlsx content'])),
+        headers: new Map([
+          ['content-disposition', 'attachment; filename="login_report_filtered_20260101_120000.xlsx"'],
+          ['content-type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+        ]),
+      });
+
+      const result = await getDownloadReport({
+        mode: 'grouped',
+        filter: 'admin_only',
+        startDate: '2025-01-01',
+        endDate: '2025-12-31',
+      });
+      expect(result).toBeDefined();
+      const fetchCall = (globalThis.fetch as any).mock.calls[0][0];
+      expect(fetchCall).toContain('mode=grouped');
+      expect(fetchCall).toContain('filter=admin_only');
+      expect(fetchCall).toContain('start_date=2025-01-01');
+      expect(fetchCall).toContain('end_date=2025-12-31');
+    });
+
+    // INDIVIDUAL MODE FILTER TESTS
+    it('should include filter=all for individual mode when filter param is all', async () => {
+      (globalThis.fetch as any).mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(['mock xlsx content'])),
+        headers: new Map([
+          ['content-disposition', 'attachment; filename="login_report_all_individual_20260101_120000.xlsx"'],
+          ['content-type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+        ]),
+      });
+
+      const result = await getDownloadReport({ mode: 'individual', filter: 'all' });
+      expect(result).toBeDefined();
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/user/dashboard/report/download/?mode=individual&filter=all'),
+        expect.any(Object)
+      );
+    });
+
+    it('should include filter=admin_only for individual mode when filter param is admin_only', async () => {
+      (globalThis.fetch as any).mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(['mock xlsx content'])),
+        headers: new Map([
+          ['content-disposition', 'attachment; filename="login_report_admin_individual_20260101_120000.xlsx"'],
+          ['content-type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+        ]),
+      });
+
+      const result = await getDownloadReport({ mode: 'individual', filter: 'admin_only' });
+      expect(result).toBeDefined();
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/user/dashboard/report/download/?mode=individual&filter=admin_only'),
+        expect.any(Object)
+      );
+    });
+
+    it('should include filter=regular_users for individual mode when filter param is regular_users', async () => {
+      (globalThis.fetch as any).mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(['mock xlsx content'])),
+        headers: new Map([
+          ['content-disposition', 'attachment; filename="login_report_regular_individual_20260101_120000.xlsx"'],
+          ['content-type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+        ]),
+      });
+
+      const result = await getDownloadReport({ mode: 'individual', filter: 'regular_users' });
+      expect(result).toBeDefined();
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/user/dashboard/report/download/?mode=individual&filter=regular_users'),
+        expect.any(Object)
+      );
+    });
+
+    it('should include filter=me for individual mode when filter param is me', async () => {
+      (globalThis.fetch as any).mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(['mock xlsx content'])),
+        headers: new Map([
+          ['content-disposition', 'attachment; filename="login_report_me_individual_20260101_120000.xlsx"'],
+          ['content-type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+        ]),
+      });
+
+      const result = await getDownloadReport({ mode: 'individual', filter: 'me' });
+      expect(result).toBeDefined();
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/user/dashboard/report/download/?mode=individual&filter=me'),
+        expect.any(Object)
+      );
+    });
+
+    it('should include role=admin for individual mode when role param is admin', async () => {
+      (globalThis.fetch as any).mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(['mock xlsx content'])),
+        headers: new Map([
+          ['content-disposition', 'attachment; filename="login_report_admin_role_individual_20260101_120000.xlsx"'],
+          ['content-type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+        ]),
+      });
+
+      const result = await getDownloadReport({ mode: 'individual', role: 'admin' });
+      expect(result).toBeDefined();
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/user/dashboard/report/download/?mode=individual&role=admin'),
+        expect.any(Object)
+      );
+    });
+
+    it('should include role=regular for individual mode when role param is regular', async () => {
+      (globalThis.fetch as any).mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(['mock xlsx content'])),
+        headers: new Map([
+          ['content-disposition', 'attachment; filename="login_report_regular_role_individual_20260101_120000.xlsx"'],
+          ['content-type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+        ]),
+      });
+
+      const result = await getDownloadReport({ mode: 'individual', role: 'regular' });
+      expect(result).toBeDefined();
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/user/dashboard/report/download/?mode=individual&role=regular'),
+        expect.any(Object)
+      );
+    });
+
+    it('should include filter, role, date, and userIds together for individual mode', async () => {
+      (globalThis.fetch as any).mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(['mock xlsx content'])),
+        headers: new Map([
+          ['content-disposition', 'attachment; filename="login_report_all_combined_20260101_120000.xlsx"'],
+          ['content-type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+        ]),
+      });
+
+      const result = await getDownloadReport({
+        mode: 'individual',
+        filter: 'regular_users',
+        role: 'admin',
+        startDate: '2025-06-01',
+        endDate: '2025-06-30',
+        userIds: [5],
+      });
+      expect(result).toBeDefined();
+      const fetchCall = (globalThis.fetch as any).mock.calls[0][0];
+      expect(fetchCall).toContain('mode=individual');
+      expect(fetchCall).toContain('filter=regular_users');
+      expect(fetchCall).toContain('role=admin');
+      expect(fetchCall).toContain('start_date=2025-06-01');
+      expect(fetchCall).toContain('end_date=2025-06-30');
+      expect(fetchCall).toContain('user_ids%5B%5D=5');
+    });
+  });
 });
+
+// Helper to import the downloadReport function after mocking
+const getDownloadReport = async (params: { mode: string; userIds?: number[]; startDate?: string; endDate?: string; filter?: string; role?: string }) => {
+  const { downloadReport } = await import('../loginTrackingService');
+  return downloadReport(params as any);
+};

--- a/src/services/apiEndpoints.ts
+++ b/src/services/apiEndpoints.ts
@@ -41,4 +41,7 @@ export const API_ENDPOINTS = {
   GAME_SCORES: "/api/game/scores/",
   GAME_SCORES_ME: "/api/game/scores/me/",
   GAME_LEADERBOARD: "/api/game/leaderboard/",
+
+  // Report Download Endpoint
+  REPORT_DOWNLOAD: "/api/user/dashboard/report/download/",
 };

--- a/src/services/loginTrackingService.ts
+++ b/src/services/loginTrackingService.ts
@@ -265,6 +265,96 @@ export const loginTrackingService = {
   },
 };
 
+// Report download result interface
+export interface DownloadReportResult {
+  blob: Blob;
+  filename: string;
+}
+
+// Download report params interface
+export interface DownloadReportParams {
+  mode: 'individual' | 'grouped';
+  userIds?: number[];
+  selectedUserId?: number;
+  startDate?: string;
+  endDate?: string;
+  filter?: 'all' | 'admin_only' | 'regular_users' | 'me';
+  role?: 'admin' | 'regular';
+}
+
+/**
+ * Download login activity summary report as Excel file
+ * Uses fetch for both production and testing (MSW compatibility)
+ */
+export const downloadReport = async (params: DownloadReportParams): Promise<DownloadReportResult> => {
+  const headers = buildHeaders();
+
+  // Build URL with query parameters
+  let url = API_ENDPOINTS.REPORT_DOWNLOAD;
+  const queryParams = new URLSearchParams();
+  
+  queryParams.append('mode', params.mode);
+
+  if (params.userIds?.length) {
+    params.userIds.forEach(id => queryParams.append('user_ids[]', id.toString()));
+  }
+
+  if (params.startDate) {
+    queryParams.append('start_date', params.startDate);
+  }
+
+  if (params.endDate) {
+    queryParams.append('end_date', params.endDate);
+  }
+
+  if (params.filter) {
+    queryParams.append('filter', params.filter);
+  }
+
+  if (params.role) {
+    queryParams.append('role', params.role);
+  }
+
+  if (params.selectedUserId !== undefined) {
+    queryParams.append('selected_user_id', params.selectedUserId.toString());
+  }
+
+  if (queryParams.toString()) {
+    url += `?${queryParams.toString()}`;
+  }
+
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers,
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      throw handleApiError(
+        { response: { status: response.status, data: errorData } },
+        { endpoint: url, operation: 'get' }
+      );
+    }
+
+    // Extract filename from Content-Disposition header
+    const disposition = response.headers.get('content-disposition');
+    let filename = 'login_report.xlsx';
+    
+    if (disposition) {
+      const match = disposition.match(/filename="(.+)"/);
+      if (match) {
+        filename = match[1];
+      }
+    }
+
+    const blob = await response.blob();
+    return { blob, filename };
+  } catch (error) {
+    throw handleApiError(error, { endpoint: url, operation: 'get' });
+  }
+};
+
 // Export individual functions for easier testing
 export const {
   getUserStats,

--- a/src/tests/mocks/handlers.ts
+++ b/src/tests/mocks/handlers.ts
@@ -1135,6 +1135,101 @@ FiFHDnq0XqBiacU8fk3NdlY8TqjxR8e9GaTTgx+UMvfR2itgEuKGfd2oImkMxC4L
     );
   }),
 
+  // Mock API for report download ----(24)
+  http.get(API_ENDPOINTS.REPORT_DOWNLOAD, async ({ request }) => {
+    const url = new URL(request.url);
+    const mode = url.searchParams.get('mode');
+    const authHeader = request.headers.get("Authorization");
+
+    // Check authentication
+    if (!authHeader || !authHeader.startsWith("JWT ")) {
+      return new HttpResponse(null, { status: 401 });
+    }
+
+    // Validate mode parameter
+    if (!mode) {
+      return HttpResponse.json(
+        { error: "Missing required parameter: 'mode'." },
+        { status: 400 }
+      );
+    }
+
+    if (mode !== 'individual' && mode !== 'grouped') {
+      return HttpResponse.json(
+        { error: "Invalid mode. Must be 'individual' or 'grouped'." },
+        { status: 400 }
+      );
+    }
+
+    // Check for regular user trying grouped mode
+    const token = authHeader.replace("JWT ", "");
+    const isAdminUser = token === "mock-admin-token" || token === "mock-staff-token";
+
+    if (mode === 'grouped' && !isAdminUser) {
+      return HttpResponse.json(
+        { error: "Only admin users can use grouped mode." },
+        { status: 403 }
+      );
+    }
+
+    // Check for regular user trying to specify user_ids
+    const user_ids = url.searchParams.getAll('user_ids[]');
+    if (user_ids.length > 0 && !isAdminUser) {
+      return HttpResponse.json(
+        { error: "Only admin users can specify user IDs." },
+        { status: 403 }
+      );
+    }
+
+    // Check for invalid date format
+    const startDate = url.searchParams.get('start_date');
+    const endDate = url.searchParams.get('end_date');
+    if (startDate && !/^\d{4}-\d{2}-\d{2}$/.test(startDate)) {
+      return HttpResponse.json(
+        { error: "Invalid date format. Use YYYY-MM-DD format." },
+        { status: 400 }
+      );
+    }
+    if (endDate && !/^\d{4}-\d{2}-\d{2}$/.test(endDate)) {
+      return HttpResponse.json(
+        { error: "Invalid date format. Use YYYY-MM-DD format." },
+        { status: 400 }
+      );
+    }
+
+    // Check for non-integer user_ids
+    if (user_ids.some(id => !/^\d+$/.test(id))) {
+      return HttpResponse.json(
+        { error: "Invalid user_ids format. Must be integers." },
+        { status: 400 }
+      );
+    }
+
+    // Generate filename based on mode
+    const now = new Date();
+    const datetime = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}${String(now.getDate()).padStart(2, '0')}_${String(now.getHours()).padStart(2, '0')}${String(now.getMinutes()).padStart(2, '0')}${String(now.getSeconds()).padStart(2, '0')}`;
+    
+    let filename: string;
+    if (mode === 'individual') {
+      const username = isAdminUser ? 'admin' : 'testuser';
+      filename = `login_report_${username}_individual_${datetime}.xlsx`;
+    } else {
+      const userCount = user_ids.length > 0 ? user_ids.length : 'all';
+      filename = `login_report_grouped_${userCount}_users_${datetime}.xlsx`;
+    }
+
+    // Generate a mock xlsx binary content (minimal valid xlsx)
+    const mockXlsxContent = new Uint8Array([80, 75, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]); // Minimal ZIP file marker for xlsx
+
+    return new HttpResponse(mockXlsxContent, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'Content-Disposition': `attachment; filename="${filename}"`,
+      },
+    });
+  }),
+
   // Mock API for game leaderboard (admin only) ----(23)
   http.get("/api/game/leaderboard/", async ({ request }) => {
     const authHeader = request.headers.get("Authorization");


### PR DESCRIPTION
## Summary Report Download Feature

This branch introduces a complete **Report Download** feature that allows users to download login activity summary reports as Excel (.xlsx) files directly from the dashboard.

###  What's New

#### 1. `ReportDownloadButton` Component (`src/components/dashboard/ReportDownloadButton.tsx`)
- **Regular users**: One-click download — triggers the report download immediately in **individual mode**
- **Admin users**: A **confirmation modal** appears before download, showing a read-only summary of current dashboard state:
  - Download mode (Individual / Grouped)
  - Active date range (if set)
  - Number of selected users / specific username
  - Filter type (all / admin / regular / me)
- Fully styled with dark/light theme support via `twin.macro`
- Download button with animated icon, disabled state during download, and error display

#### 2. `downloadReport` API Service (`src/services/loginTrackingService.ts`)
- New `downloadReport()` function using `fetch` for both production and MSW testing
- Accepts flexible parameters: `mode`, `userIds[]`, `selected_user_id`, `start_date`, `end_date`, `filter`, `role`
- Parses `Content-Disposition` header to extract the filename from the backend
- Returns a `Blob` + `filename` object for browser download via a temporary `<a>` element
- Integrated with centralized error handling

#### 3. API Endpoint (`src/services/apiEndpoints.ts`)
- Added `REPORT_DOWNLOAD` endpoint constant mapped to the backend URL

#### 4. i18n Translations (`src/locale/i18n.ts`)
- 39 new translation keys across all supported languages for:
  - Button label, downloading state
  - Modal title, summary section labels
  - Mode labels (individual/grouped)
  - Cancel/download action buttons
  - Error messages

#### 5. Dashboard Container Integration (`src/components/dashboard/DashboardContainer.tsx`)
- Integrated the `ReportDownloadButton` into the header area
- Passes `isAdmin` prop from Redux auth state

#### 6. MSW Mock Handlers (`src/tests/mocks/handlers.ts`)
- Added mock handler for the download endpoint returning binary Excel data with proper headers

#### 7. Comprehensive Test Coverage
- **`ReportDownloadButton.test.tsx`** — Full coverage including:
  - Renders download button
  - Regular user: triggers download on click
  - Admin user: shows confirmation modal with summary info
  - Modal cancel/download actions
  - Loading/disabled states
  - Error display
  - Mode and date range display in modal
  - Grouped/individual mode parameter passing
- **`ReportDownloadButton.i18n.test.tsx`** — i18n key verification
- **`loginTrackingService.test.ts`** — Updated with download report tests

### 🧪 How It Works
1. The dashboard state (`chartMode`, `selectedDashboardUserId`, `startDate`/`endDate`, `activeFilter`) drives the download parameters
2. Regular users download immediately; admins review a summary modal first
3. The backend generates the Excel file, and the frontend triggers a browser file save
4. Dark mode fully supported across button, modal overlay, summary box, and action buttons

### 🔗 Related Files
- `src/components/dashboard/ReportDownloadButton.tsx`
- `src/components/dashboard/ReportDownloadButton.test.tsx`
- `src/components/dashboard/ReportDownloadButton.i18n.test.tsx`
- `src/services/loginTrackingService.ts` (downloadReport function)
- `src/services/apiEndpoints.ts` (REPORT_DOWNLOAD)
- `src/locale/i18n.ts` (translation keys)
- `src/tests/mocks/handlers.ts` (MSW handler)
- `src/components/dashboard/DashboardContainer.tsx` (integration)
- `src/components/dashboard/DashboardContainer.test.tsx` (updated)
