### PR TITLE
fix: reset selected file and image preview on profile edit cancel

### DIFF
--- a/src/page/ProfilePage.test.tsx
+++ b/src/page/ProfilePage.test.tsx
@@ -859,6 +859,44 @@ describe("ProfilePage", () => {
       });
     });
 
+    it("clears selected file and image preview when canceling edit mode", async () => {
+      await setup();
+
+      // Wait for user data to load
+      await waitFor(() =>
+        expect(screen.getByTestId("username")).toBeInTheDocument()
+      );
+
+      // Enter edit mode
+      fireEvent.click(screen.getByTestId("edit-profile-button"));
+
+      // Select a file
+      const file = new File(["dummy content"], "test-image.jpg", {
+        type: "image/jpeg",
+      });
+      const fileInput = screen.getByTestId("image-file-input");
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      // Verify preview is shown
+      await waitFor(() => {
+        expect(screen.getByTestId("image-preview")).toBeInTheDocument();
+      });
+
+      // Click cancel button
+      fireEvent.click(screen.getByTestId("cancel-edit-button"));
+
+      // Re-enter edit mode
+      fireEvent.click(screen.getByTestId("edit-profile-button"));
+
+      // Verify the preview is no longer displayed (cleared on cancel)
+      await waitFor(() => {
+        expect(screen.queryByTestId("image-preview")).not.toBeInTheDocument();
+      });
+
+      // Verify the "No file chosen" text is shown instead of the file name
+      expect(screen.getByText("Choose file")).toBeInTheDocument();
+    });
+
     it("stays on ProfilePage when canceling edit form accessed directly", async () => {
       const { mockNavigate } = await setup();
 

--- a/src/page/ProfilePage.tsx
+++ b/src/page/ProfilePage.tsx
@@ -195,6 +195,11 @@ class ProfilePage extends Component<ProfilePageProps, ProfilePageState> {
       return;
     }
 
+    // Clean up previous blob URL if it exists
+    if (this.state.imagePreviewUrl && URL.revokeObjectURL) {
+      URL.revokeObjectURL(this.state.imagePreviewUrl);
+    }
+
     this.setState((prevState) => ({
       isEditing: !prevState.isEditing,
       // Reset form data when entering edit mode
@@ -205,6 +210,9 @@ class ProfilePage extends Component<ProfilePageProps, ProfilePageState> {
       },
       validationErrors: {},
       successMessage: null,
+      selectedFile: null,
+      clearImage: false,
+      imagePreviewUrl: null,
     }));
   };
 


### PR DESCRIPTION
When canceling the edit profile form, the component was only resetting editForm fields, validation errors, and success message — but not the selectedFile, imagePreviewUrl, and clearImage state properties. This caused previously selected files and image previews to persist when re-entering edit mode.

- Add blob URL cleanup and revoke in toggleEditMode
- Reset selectedFile, clearImage, and imagePreviewUrl when toggling edit mode
- Add test verifying file selection and preview are cleared after cancel
