### PR TITLE
fix_test_noise

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -84,6 +84,10 @@ const mockAuth = (
 
 describe("App", () => {
   beforeEach(async () => {
+    // Suppress expected console.error from error handling tests to keep test output clean
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    // Suppress React Router "No routes matched" warnings from ProtectedRoute redirect tests
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
     // Reset Redux auth state before each test
     store.dispatch(logoutSuccess());
     // Clear localStorage
@@ -95,6 +99,7 @@ describe("App", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     // Clean up and reset state after each test
     store.dispatch(logoutSuccess());
     window.localStorage.clear();
@@ -191,6 +196,10 @@ describe("Error Handling", () => {
 
 describe("Routing", () => {
   beforeEach(async () => {
+    // Suppress expected console.error from error handling tests to keep test output clean
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    // Suppress React Router "No routes matched" warnings from ProtectedRoute redirect tests
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
     // Make beforeEach async
     // Reset Redux auth state before each test
     store.dispatch(logoutSuccess());

--- a/src/components/dashboard/DashboardContainer.test.tsx
+++ b/src/components/dashboard/DashboardContainer.test.tsx
@@ -144,6 +144,10 @@ vi.mock('./ReportDownloadButton', () => ({
 }));
 
 describe('DashboardContainer', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
   // Basic rendering tests (fast, lightweight)
   describe('Basic Rendering', () => {
     // Mock the entire DashboardContainer component for basic rendering tests

--- a/src/components/dashboard/ReportDownloadButton.test.tsx
+++ b/src/components/dashboard/ReportDownloadButton.test.tsx
@@ -69,6 +69,7 @@ const renderWithProviders = (component: React.ReactElement, dashboardState = {},
 
 describe('ReportDownloadButton', () => {
   beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.clearAllMocks();
     // Ensure document starts without dark class
     document.documentElement.classList.remove('dark');

--- a/src/components/dashboard/__tests__/DashboardUserList.test.tsx
+++ b/src/components/dashboard/__tests__/DashboardUserList.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { I18nextProvider } from 'react-i18next';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
@@ -69,7 +69,13 @@ describe('DashboardUserList', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Suppress expected console.error from error handling tests to keep test output clean
+    vi.spyOn(console, 'error').mockImplementation(() => {});
     mockGetUsers.mockResolvedValue(mockPaginatedResponse);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   describe('Rendering', () => {

--- a/src/components/logout/useLogout.test.tsx
+++ b/src/components/logout/useLogout.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -46,6 +46,8 @@ describe("useLogout Hook", () => {
       );
 
   beforeEach(() => {
+    // Suppress expected console.error from error handling tests to keep test output clean
+    vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.clearAllMocks();
     store = createStore();
     mockApiService = {
@@ -65,8 +67,13 @@ describe("useLogout Hook", () => {
         staff_access_granted: false,
         active_role: 'regular' as const,
         role_label: 'Regular',
-    })
+      })
     );
+  });
+
+  afterEach(() => {
+    // Use clearAllMocks instead of restoreAllMocks to avoid restoring module-level spies (e.g., window.dispatchEvent)
+    vi.clearAllMocks();
   });
 
   it("perform complete logout flow successfully", async () => {

--- a/src/page/LoginPage.test.tsx
+++ b/src/page/LoginPage.test.tsx
@@ -38,6 +38,9 @@ vi.mock("react-router-dom", async (importOriginal) => {
 
   beforeEach(async () => {
     vi.resetAllMocks();
+    // Suppress expected console.error and console.warn from error handling tests to keep test output clean
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
     mockedNavigate.mockClear(); // Clear navigate mock before each test
     store.dispatch(logoutSuccess()); // Reset Redux auth state before each test
     store.dispatch(resetDashboardState()); // Reset dashboard state before each test

--- a/src/page/ResetPasswordPage.test.tsx
+++ b/src/page/ResetPasswordPage.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { render, screen, act, waitFor } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import axios from "axios";
-import { vi, beforeEach } from "vitest";
+import { vi, beforeEach, afterEach } from "vitest";
 import { defaultService } from "../services/defaultService";
 import {
   fetchApiServiceResetPassword,
@@ -29,6 +29,8 @@ vi.mock("react-router-dom", async (importOriginal) => {
 });
 
 beforeEach(async () => {
+  // Suppress expected console.error from error handling tests to keep test output clean
+  vi.spyOn(console, 'error').mockImplementation(() => {});
   vi.resetAllMocks();
   mockedNavigate.mockClear();
   window.localStorage.clear();
@@ -36,6 +38,10 @@ beforeEach(async () => {
   await act(async () => {
     await i18n.changeLanguage("en");
   });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 // Helper function to render the component wrapped with Provider and MemoryRouter

--- a/src/page/SignUpPage.spec.tsx
+++ b/src/page/SignUpPage.spec.tsx
@@ -9,7 +9,7 @@ import {
 } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import axios from "axios";
-import { vi, beforeEach } from "vitest";
+import { vi, beforeEach, afterEach } from "vitest";
 import { fillAndSubmitSignUpForm } from "../tests/testUtils";
 import {
   axiosApiServiceSignUp,
@@ -25,7 +25,13 @@ vi.mock("axios");
 const mockedAxios = vi.mocked(axios, { deep: true });
 
 beforeEach(() => {
+  // Suppress expected console.error from error handling tests to keep test output clean
+  vi.spyOn(console, 'error').mockImplementation(() => {});
   vi.resetAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 describe("signup page", () => {

--- a/src/page/VerifyEmailPage.test.tsx
+++ b/src/page/VerifyEmailPage.test.tsx
@@ -40,6 +40,7 @@ describe('VerifyEmailPage', () => {
   const mockT = (key: string) => key;
 
   beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
     (useTranslation as any).mockReturnValue({ t: mockT });
   });
 
@@ -472,6 +473,7 @@ describe('VerifyEmailPage i18n Language Switching', () => {
   };
 
   beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.resetAllMocks();
   });
 
@@ -528,13 +530,15 @@ describe('VerifyEmailPage i18n Language Switching', () => {
       // Trigger re-render by changing a prop or forcing update
       // Since we can't easily trigger language change in the component,
       // we'll re-render with the new translation function
+      const container = document.createElement('div');
+      document.body.appendChild(container);
       render(
         <Provider store={store}>
           <MemoryRouter>
             <VerifyEmailPage apiService={mockApiService} resendApiService={mockResendApiService} />
           </MemoryRouter>
         </Provider>,
-        { container: document.body }
+        { container }
       );
 
       // The error message should NOW be in toLang if the component is working correctly

--- a/src/page/accountActivationPage.test.tsx
+++ b/src/page/accountActivationPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import AccountActivationPage from "./accountActivationPage";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import axios from "axios";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import {
@@ -15,6 +15,12 @@ const mockedAxios = vi.mocked(axios, { deep: true });
 
 beforeEach(() => {
   vi.restoreAllMocks(); // Clears all spies/mocks before each test
+  // Suppress expected console.error from error handling tests to keep test output clean
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 /**

--- a/src/services/__tests__/apiService.test.ts
+++ b/src/services/__tests__/apiService.test.ts
@@ -23,8 +23,10 @@ vi.mock("../../store", () => ({
 const mockedStore = store as any;
 
 describe("API Service Authentication", () => {
+  // Suppress expected console.error from error handling tests to keep test output clean
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
     // Reset store mock
     mockedStore.getState.mockReturnValue({
       auth: {

--- a/src/services/__tests__/djangoErrorHandling.test.ts
+++ b/src/services/__tests__/djangoErrorHandling.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { axiosApiServiceSignUp, fetchApiServiceSignUp } from "../apiService";
 import axios from "axios";
 import { handleDjangoErrors } from "../../utils/djangoErrorHandler";
@@ -7,6 +7,15 @@ vi.mock("axios");
 const mockedAxios = vi.mocked(axios, { deep: true });
 
 describe("Django Error Handling", () => {
+  // Suppress expected console.error from error handling tests to keep test output clean
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   describe("axiosApiServiceSignUp", () => {
     it("should handle Django error response format correctly", async () => {
       // Mock Django error response format (array of errors)

--- a/src/services/__tests__/emailVerification.api.test.ts
+++ b/src/services/__tests__/emailVerification.api.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import axios from "axios";
 import {
   axiosApiServiceVerifyEmail,
@@ -32,7 +32,13 @@ vi.mock("../../store", () => ({
 }));
 
 describe("Email Verification API Services", () => {
+  // Suppress expected console.error from error handling tests to keep test output clean
   beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
     vi.restoreAllMocks();
   });
 

--- a/src/services/__tests__/errorService.handleApiError.test.ts
+++ b/src/services/__tests__/errorService.handleApiError.test.ts
@@ -1,7 +1,15 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { handleApiError } from '../errorService';
 
 describe('handleApiError - Centralized API Error Handler', () => {
+  // Suppress expected console.error from error handling tests to keep test output clean
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
   it('should handle network errors (status 0)', () => {
     const networkError = {
       message: 'Network Error',

--- a/src/services/__tests__/errorService.i18n.test.ts
+++ b/src/services/__tests__/errorService.i18n.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import i18n from "../../locale/i18n";
 import { handleApiError } from "../errorService";
 import { act } from "@testing-library/react";
@@ -11,9 +11,15 @@ const changeLanguage = async (lang: string) => {
 };
 
 describe("handleApiError - i18n", () => {
+  // Suppress expected console.error from error handling tests to keep test output clean
   beforeEach(async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
     // Reset to English before each test
     await changeLanguage("en");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   // Test cases for different languages

--- a/src/services/__tests__/loginTrackingService.chartData.test.ts
+++ b/src/services/__tests__/loginTrackingService.chartData.test.ts
@@ -2,7 +2,7 @@
  * Login Tracking Service Chart Data Extraction Tests
  * Tests the chart data extraction from backend wrapper objects
  */
-import { describe, it, expect, beforeEach, beforeAll, vi } from 'vitest';
+import { describe, it, expect, beforeEach, beforeAll, afterEach, vi } from 'vitest';
 import { http, HttpResponse } from 'msw';
 import { API_ENDPOINTS } from '../apiEndpoints';
 import { getLoginTrends, getLoginComparison, getLoginDistribution } from '../loginTrackingService';
@@ -33,6 +33,12 @@ describe('Login Tracking Service - Chart Data Extraction', () => {
   beforeEach(() => {
     // Reset any mocks
     vi.clearAllMocks();
+    // Suppress expected console.error from error handling tests to keep test output clean
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   describe('getLoginTrends', () => {

--- a/src/services/__tests__/logout.test.ts
+++ b/src/services/__tests__/logout.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { axiosApiServiceLogout, fetchApiServiceLogout } from "../apiService";
 import { API_ENDPOINTS } from "../apiEndpoints";
 
@@ -20,6 +20,15 @@ vi.mock("../../store", () => ({
 }));
 
 describe("Logout Error Handling with MSW", () => {
+  // Suppress expected console.error from error handling tests to keep test output clean
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   describe("axiosApiServiceLogout", () => {
     it("should handle 'refresh_token_not_valid' error when invalid refresh token provided", async () => {
       // Test the actual MSW handler with invalid refresh token from store

--- a/src/services/tokenService.test.ts
+++ b/src/services/tokenService.test.ts
@@ -30,6 +30,8 @@ const mockedAxios = axios as any;
 describe("tokenService", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Suppress expected console.error from error handling tests to keep test output clean
+    vi.spyOn(console, 'error').mockImplementation(() => {});
     store.dispatch(
       loginSuccess({
         id: 1,

--- a/src/store/globalErrorSlice.test.ts
+++ b/src/store/globalErrorSlice.test.ts
@@ -1,7 +1,15 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import globalErrorReducer, { setGlobalError, clearGlobalError } from './globalErrorSlice';
 
 describe('globalErrorSlice', () => {
+  // Suppress expected console.error from error handling tests to keep test output clean
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
   const initialState = {
     error: null,
   };

--- a/src/tests/components/game/DrawCircleGame.test.tsx
+++ b/src/tests/components/game/DrawCircleGame.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { I18nextProvider } from 'react-i18next';
 import { Provider } from 'react-redux';
@@ -22,6 +22,11 @@ const renderWithProviders = (ui: React.ReactElement) => {
 
 describe('DrawCircleGame', () => {
   beforeEach(() => {
+    // Suppress expected console.error from error handling tests to keep test output clean
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    // Mock canvas getContext since jsdom doesn't implement it
+    HTMLCanvasElement.prototype.getContext = vi.fn() as any;
+
     act(() => {
       store.dispatch(loginSuccess({
         id: 1,
@@ -39,6 +44,7 @@ describe('DrawCircleGame', () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     act(() => {
       store.dispatch(logoutSuccess());
     });

--- a/src/tests/services/gameService.test.ts
+++ b/src/tests/services/gameService.test.ts
@@ -2,7 +2,7 @@
  * Game Service Tests
  * Tests for the "Draw a Circle" game API service
  */
-import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach, beforeEach, vi } from 'vitest';
 import { http, HttpResponse } from 'msw';
 import { server } from '../mocks/server';
 import { API_ENDPOINTS } from '../../services/apiEndpoints';
@@ -36,16 +36,22 @@ const setAuthState = (token: string | null, isStaff: boolean = false) => {
 };
 
 describe('Game Service', () => {
+  // Suppress expected console.error from error handling tests to keep test output clean
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    server.resetHandlers();
+  });
+
   beforeAll(() => {
     setAuthState('mock-access-token');
   });
 
   afterAll(() => {
     setAuthState(null);
-  });
-
-  afterEach(() => {
-    server.resetHandlers();
   });
 
   describe('saveGameScore', () => {


### PR DESCRIPTION
**Title:** `fix: silence expected console noise in Vitest suites`

**Summary:**
Cleans up noisy test output by mocking `console.error`/`console.warn` in test suites where expected error-handling paths print to the console, and adds `afterEach(() => vi.restoreAllMocks())` to restore spies. Also fixes a `VerifyEmailPage` render-container hack and mocks `canvas.getContext` in `DrawCircleGame`. No production code changed