### PR TITLE
feat: add ScrollToTop component to scroll to top on route navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import GlobalErrorDisplay from "./components/GlobalErrorDisplay";
 import { ReactElement } from "react";
 import { PageTransition } from "./components/common/PageTransition";
 import { LanguageTransition } from "./components/common/LanguageTransition";
+import { ScrollToTop } from "./components/common/ScrollToTop";
 
 // Navbar styled components
 const NavBar = tw.nav`
@@ -514,6 +515,7 @@ export const AppContent = ({
 // Production version with Router
 const AppWithRouter = () => (
   <Router>
+    <ScrollToTop />
     <AppContent />
   </Router>
 );

--- a/src/components/common/ScrollToTop.test.tsx
+++ b/src/components/common/ScrollToTop.test.tsx
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, act, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, Link } from "react-router-dom";
+import { ScrollToTop } from "./ScrollToTop";
+
+describe("ScrollToTop", () => {
+  beforeEach(() => {
+    vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders nothing (returns null)", () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={["/"]}>
+        <ScrollToTop />
+      </MemoryRouter>
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("calls window.scrollTo(0, 0) on initial mount", () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <ScrollToTop />
+      </MemoryRouter>
+    );
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+  });
+
+  it("calls window.scrollTo when navigating to a different route via Link click", () => {
+    const NavigationTest = () => (
+      <MemoryRouter initialEntries={["/page1"]}>
+        <ScrollToTop />
+        <nav>
+          <Link to="/page2" data-testid="nav-link">Go to Page 2</Link>
+        </nav>
+        <Routes>
+          <Route path="/page1" element={<div>Page 1</div>} />
+          <Route path="/page2" element={<div>Page 2</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    render(<NavigationTest />);
+
+    // Should have been called on initial mount
+    expect(window.scrollTo).toHaveBeenCalledTimes(1);
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+
+    // Click the link to navigate to page2
+    act(() => {
+      fireEvent.click(screen.getByTestId("nav-link"));
+    });
+
+    // Should have been called again after navigation
+    expect(window.scrollTo).toHaveBeenCalledTimes(2);
+    expect(window.scrollTo).toHaveBeenLastCalledWith(0, 0);
+  });
+});

--- a/src/components/common/ScrollToTop.tsx
+++ b/src/components/common/ScrollToTop.tsx
@@ -1,0 +1,17 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+/**
+ * ScrollToTop - scrolls the window to the top whenever the route pathname changes.
+ * This ensures users see the top of each new page when navigating via the navbar.
+ * Renders nothing (returns null).
+ */
+export const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};


### PR DESCRIPTION
When navigating between pages via the navbar, the browser preserves the scroll position from the previous page,
causing the new page to appear scrolled down.
This adds a ScrollToTop component that listens to route changes and scrolls the window to the top,
ensuring users always see the page title and description section when landing on a new page.

Changes:
- Implement ScrollToTop component using useLocation + useEffect
- Add ScrollToTop inside Router in AppWithRouter (App.tsx)
- Include TDD tests: renders null, scrolls on mount, scrolls on route change