### PR TITLE
fix(store): remove duplicate SecureLS writes from authSlice

### DIFF
--- a/src/store/authSlice.test.ts
+++ b/src/store/authSlice.test.ts
@@ -66,6 +66,28 @@ describe("Auth Slice", () => {
     expect(newStore.getState().auth.user).toBeNull();
   });
 
+  it("should not duplicate SecureLS writes on login (redundancy check)", () => {
+    const store = createStore();
+    const testUser = {
+      id: 1,
+      username: "testuser",
+      is_staff: false,
+      is_superuser: false,
+      logins_remaining_for_staff: 0,
+      staff_access_granted: false,
+      active_role: 'regular' as const,
+      role_label: 'Regular',
+      access: "test-access-token",
+      refresh: "test-refresh-token",
+    };
+
+    store.dispatch(loginSuccess(testUser));
+
+    // SecureLS.set should be called exactly once (by store subscription, not by slice)
+    expect(mockSecureLS.setCalls.length).toBe(1);
+    expect(mockSecureLS.setCalls[0].key).toBe("authState");
+  });
+
   it("should store tokens in SecureLS and restore auth state from session storage on store creation", () => {
     const store = createStore();
     const testUser = {

--- a/src/store/authSlice.ts
+++ b/src/store/authSlice.ts
@@ -1,9 +1,5 @@
 import { createSlice } from "@reduxjs/toolkit";
-import SecureLS from "secure-ls";
 import { loginSuccess, logoutSuccess } from "./actions";
-
-// Initialize SecureLS
-const secureLS = new SecureLS({ encodingType: "aes" });
 
 export interface AuthState {
   isAuthenticated: boolean;
@@ -65,30 +61,12 @@ const authSlice = createSlice({
         state.accessToken = action.payload.access;
         state.refreshToken = action.payload.refresh;
         state.showLogoutMessage = false; // Ensure logout message is hidden on login
-        // Store tokens in secure storage
-        secureLS.set("authState", {
-          isAuthenticated: true,
-          user: {
-            id: action.payload.id,
-            username: action.payload.username,
-            is_staff: action.payload.is_staff,
-            is_superuser: action.payload.is_superuser,
-            logins_remaining_for_staff: action.payload.logins_remaining_for_staff,
-            staff_access_granted: action.payload.staff_access_granted,
-            active_role: action.payload.active_role,
-            role_label: action.payload.role_label,
-          },
-          accessToken: action.payload.access,
-          refreshToken: action.payload.refresh,
-          showLogoutMessage: false, // Ensure logout message is hidden in storage too
-        });
       })
       .addCase(logoutSuccess, (state) => {
         state.isAuthenticated = false;
         state.user = null;
         state.accessToken = null;
         state.refreshToken = null;
-        secureLS.remove("authState");
       });
   },
 });


### PR DESCRIPTION
authSlice.ts was calling secureLS.set/remove directly AND through store subscription, doubling every persistence operation. Removed the redundant calls — all persistence is now centralized in store/index.ts saveState().