### PR TITLE
refactor(store): consolidate duplicate auth types and remove dead code

### DIFF
--- a/src/store/authSlice.ts
+++ b/src/store/authSlice.ts
@@ -1,22 +1,5 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-
-export interface AuthState {
-  isAuthenticated: boolean;
-  user: {
-    id: number;
-    username: string;
-    image?: string;
-    is_staff: boolean;
-    is_superuser: boolean;
-    logins_remaining_for_staff: number;
-    staff_access_granted: boolean;
-    active_role: 'regular' | 'staff' | 'superuser';
-    role_label: string;
-  } | null;
-  accessToken: string | null;
-  refreshToken: string | null;
-  showLogoutMessage: boolean;
-}
+import { AuthState, LoginPayload } from "./types";
 
 const initialState: AuthState = {
   isAuthenticated: false,
@@ -25,19 +8,6 @@ const initialState: AuthState = {
   refreshToken: null,
   showLogoutMessage: false,
 };
-
-interface LoginPayload {
-  id: number;
-  username: string;
-  access: string;
-  refresh: string;
-  is_staff: boolean;
-  is_superuser: boolean;
-  logins_remaining_for_staff: number;
-  staff_access_granted: boolean;
-  active_role: 'regular' | 'staff' | 'superuser';
-  role_label: string;
-}
 
 const authSlice = createSlice({
   name: "auth",

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,38 +1,22 @@
 import { configureStore } from "@reduxjs/toolkit";
 import rootReducer from "./rootReducer";
 import SecureLS from "secure-ls";
+import { AuthState } from "./types";
 
 const secureLS = new SecureLS({ encodingType: "aes" });
 
-interface PersistedAuthState {
-  isAuthenticated: boolean;
-  user: {
-    id: number;
-    username: string;
-    is_staff: boolean;
-    is_superuser: boolean;
-    logins_remaining_for_staff: number;
-    staff_access_granted: boolean;
-    active_role: 'regular' | 'staff' | 'superuser';
-    role_label: string;
-  } | null;
-  accessToken: string | null;
-  refreshToken: string | null;
-  showLogoutMessage: boolean;
-}
-
 interface RootStateForPersistence {
-  auth: PersistedAuthState;
+  auth: AuthState;
 }
 
 const AUTH_STORAGE_KEY = "authState";
 
-const isPersistedAuthState = (value: unknown): value is PersistedAuthState => {
+const isPersistedAuthState = (value: unknown): value is AuthState => {
   if (!value || typeof value !== "object") {
     return false;
   }
 
-  const authValue = value as Partial<PersistedAuthState>;
+  const authValue = value as Partial<AuthState>;
   const userValue = authValue.user;
 
   const isValidUser =
@@ -60,7 +44,7 @@ const DEFAULT_AUTH_FIELDS = {
   role_label: "Regular",
 };
 
-const migrateAuthUser = (user: PersistedAuthState["user"]): PersistedAuthState["user"] => {
+const migrateAuthUser = (user: AuthState["user"]): AuthState["user"] => {
   if (!user) return null;
   return {
     ...DEFAULT_AUTH_FIELDS,

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -15,7 +15,35 @@ export interface UserState {
   error: string | null;
 }
 
-// Represents the payload for the updateSuccess action
-export type UpdateSuccessPayload = {
-  user: User;
-};
+// Auth State Interfaces
+
+export interface AuthState {
+  isAuthenticated: boolean;
+  user: {
+    id: number;
+    username: string;
+    image?: string;
+    is_staff: boolean;
+    is_superuser: boolean;
+    logins_remaining_for_staff: number;
+    staff_access_granted: boolean;
+    active_role: 'regular' | 'staff' | 'superuser';
+    role_label: string;
+  } | null;
+  accessToken: string | null;
+  refreshToken: string | null;
+  showLogoutMessage: boolean;
+}
+
+export interface LoginPayload {
+  id: number;
+  username: string;
+  access: string;
+  refresh: string;
+  is_staff: boolean;
+  is_superuser: boolean;
+  logins_remaining_for_staff: number;
+  staff_access_granted: boolean;
+  active_role: 'regular' | 'staff' | 'superuser';
+  role_label: string;
+}


### PR DESCRIPTION
- Remove unused UpdateSuccessPayload type from types.ts (dead code)
- Move AuthState and LoginPayload from authSlice.ts to types.ts
- Replace inline PersistedAuthState in store/index.ts with shared AuthState
- Remove inline interface definitions from authSlice.ts

Now auth types have a single source of truth in types.ts, preventing type drift between authSlice.ts and store/index.ts.